### PR TITLE
Expand vocabulary study app with spaced repetition and new drills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>背单词小助手</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>背单词小助手</h1>
+    <p>结合艾宾浩斯遗忘曲线，科学规划考研与 GRE 词汇记忆</p>
+  </header>
+
+  <main class="app-main">
+    <section class="controls" aria-label="词库与复习控制">
+      <div class="control-group">
+        <label for="word-pack">词库：</label>
+        <select id="word-pack" aria-label="选择词库"></select>
+      </div>
+      <div class="control-group">
+        <button id="shuffle" class="secondary">随机重排</button>
+        <button id="reset-review" class="ghost" title="清除本词库的复习记录">重置复习数据</button>
+      </div>
+    </section>
+
+    <section class="mode-selector" aria-label="练习模式">
+      <button class="mode-button active" data-mode="flashcard">闪卡记忆</button>
+      <button class="mode-button" data-mode="spelling">拼写强化</button>
+      <button class="mode-button" data-mode="confusion">形近词辨析</button>
+    </section>
+
+    <section class="mode-panel" id="flashcard-panel" data-mode-panel="flashcard" aria-live="polite">
+      <div class="flashcard">
+        <div class="flashcard-front">
+          <p class="label">英文</p>
+          <p id="word" class="content">加载中...</p>
+          <p id="phonetic" class="phonetic"></p>
+        </div>
+        <div class="flashcard-back">
+          <p class="label">释义</p>
+          <p id="definition" class="content">点击“显示释义”查看</p>
+          <p id="example" class="example"></p>
+          <div id="confusion-hints" class="hints" aria-live="polite"></div>
+        </div>
+      </div>
+      <div class="actions">
+        <button id="show-definition" class="primary">显示释义</button>
+        <div class="action-group">
+          <button id="mark-remembered" class="success">记住啦</button>
+          <button id="next-word" class="secondary">下一个</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="mode-panel" id="spelling-panel" data-mode-panel="spelling" hidden>
+      <header class="panel-header">
+        <h2>拼写强化</h2>
+        <p>根据释义和音标输入正确拼写，强化拼写肌肉记忆。</p>
+      </header>
+      <div class="prompt">
+        <p class="label">释义</p>
+        <p id="spelling-definition" class="content">选择词库后开始练习</p>
+        <p id="spelling-phonetic" class="phonetic"></p>
+      </div>
+      <div class="input-group">
+        <label for="spelling-input">请拼写该单词：</label>
+        <input id="spelling-input" type="text" autocomplete="off" spellcheck="false" />
+        <button id="spelling-check" class="primary">检查</button>
+      </div>
+      <p id="spelling-feedback" class="feedback" role="status"></p>
+      <button id="spelling-next" class="secondary">换一个</button>
+    </section>
+
+    <section class="mode-panel" id="confusion-panel" data-mode-panel="confusion" hidden>
+      <header class="panel-header">
+        <h2>形近词辨析</h2>
+        <p>在常见易混淆词之间做选择，掌握核心差异。</p>
+      </header>
+      <div class="prompt">
+        <p class="label">提示</p>
+        <p id="confusion-definition" class="content">选择词库后开始练习</p>
+        <p id="confusion-tip" class="tip"></p>
+      </div>
+      <div id="confusion-options" class="option-list" role="group" aria-label="形近词选项"></div>
+      <p id="confusion-feedback" class="feedback" role="status"></p>
+      <button id="confusion-next" class="secondary">下一题</button>
+    </section>
+
+    <section class="progress" aria-live="polite">
+      <div class="progress-text">
+        <span><strong id="progress-count">0</strong>/<span id="total-count">0</span> 已巩固</span>
+        <span id="due-count" class="due-count">0 个待复习</span>
+      </div>
+      <div class="progress-bar">
+        <div id="progress-fill" role="progressbar" aria-valuemin="0" aria-valuemax="100"></div>
+      </div>
+    </section>
+
+    <section class="review-plan">
+      <h2>艾宾浩斯复习安排</h2>
+      <p>按照 5 分钟、30 分钟、12 小时、1 天、2 天、4 天、7 天的节奏复习，最大化记忆保持率。</p>
+      <ul id="review-list" aria-live="polite"></ul>
+    </section>
+
+    <section class="word-list">
+      <h2>本次练习单词</h2>
+      <ul id="word-list"></ul>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>提示：坚持复习到“绿灯”全亮，再扩充下一个词库！</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,804 @@
+const WORD_PACKS = {
+  "考研词汇": [
+    {
+      word: "ameliorate",
+      definition: "v. 改善；使好转",
+      phonetic: "əˈmiːliəreɪt",
+      example: "A well-structured review plan can ameliorate exam anxiety.",
+      confusions: [
+        { word: "deteriorate", definition: "v. 恶化；退化" },
+        { word: "alleviate", definition: "v. 缓解；减轻" }
+      ]
+    },
+    {
+      word: "meticulous",
+      definition: "adj. 一丝不苟的；严谨的",
+      phonetic: "məˈtɪkjələs",
+      example: "She kept meticulous notes of every practice test.",
+      confusions: [
+        { word: "fastidious", definition: "adj. 挑剔的；极其注意细节的" }
+      ]
+    },
+    {
+      word: "exacerbate",
+      definition: "v. 使恶化；使加剧",
+      phonetic: "ɪɡˈzæsəbeɪt",
+      example: "Skipping reviews will exacerbate the forgetting problem.",
+      confusions: [
+        { word: "exasperate", definition: "v. 激怒；使恼怒" }
+      ]
+    },
+    {
+      word: "pragmatic",
+      definition: "adj. 务实的；讲求实际的",
+      phonetic: "præɡˈmætɪk",
+      example: "A pragmatic learner blends flashcards with writing practice.",
+      confusions: [
+        { word: "dogmatic", definition: "adj. 教条的；武断的" }
+      ]
+    },
+    {
+      word: "delineate",
+      definition: "v. 描述；勾画轮廓",
+      phonetic: "dɪˈlɪnieɪt",
+      example: "The teacher delineated the key grammar points in detail.",
+      confusions: [
+        { word: "eliminate", definition: "v. 消除；淘汰" }
+      ]
+    },
+    {
+      word: "ubiquitous",
+      definition: "adj. 无处不在的；普遍存在的",
+      phonetic: "juːˈbɪkwɪtəs",
+      example: "Mobile apps make ubiquitous learning possible.",
+      confusions: [
+        { word: "unique", definition: "adj. 独一无二的" }
+      ]
+    },
+    {
+      word: "pertinent",
+      definition: "adj. 相关的；中肯的",
+      phonetic: "ˈpɜːrtɪnənt",
+      example: "Only pertinent examples are kept in the final notes.",
+      confusions: [
+        { word: "impertinent", definition: "adj. 无礼的；不相关的" }
+      ]
+    },
+    {
+      word: "alleviate",
+      definition: "v. 缓解；减轻",
+      phonetic: "əˈliːvieɪt",
+      example: "Regular breaks can alleviate fatigue during revision.",
+      confusions: [
+        { word: "aggravate", definition: "v. 加重；恶化" }
+      ]
+    },
+    {
+      word: "galvanize",
+      definition: "v. 激励；通电镀锌",
+      phonetic: "ˈɡælvənaɪz",
+      example: "The looming exam date galvanized her to study harder.",
+      confusions: [
+        { word: "paralyze", definition: "v. 使瘫痪；使麻痹" }
+      ]
+    },
+    {
+      word: "consolidate",
+      definition: "v. 巩固；合并",
+      phonetic: "kənˈsɑːlɪdeɪt",
+      example: "Daily review consolidates long-term memory.",
+      confusions: [
+        { word: "liquidate", definition: "v. 清算；变现" }
+      ]
+    }
+  ],
+  "GRE词汇": [
+    {
+      word: "abrogate",
+      definition: "v. 废除；撤销",
+      phonetic: "ˈæbrəɡeɪt",
+      example: "The committee voted to abrogate the outdated rule.",
+      confusions: [
+        { word: "arrogate", definition: "v. 冒称拥有；霸占" }
+      ]
+    },
+    {
+      word: "intransigent",
+      definition: "adj. 不妥协的；固执的",
+      phonetic: "ɪnˈtrænsɪdʒənt",
+      example: "The negotiator faced an intransigent opponent.",
+      confusions: [
+        { word: "insurgent", definition: "n. 叛乱者；起义者" }
+      ]
+    },
+    {
+      word: "proscribe",
+      definition: "v. 禁止；取缔",
+      phonetic: "proʊˈskraɪb",
+      example: "The policy proscribed the use of informal sources.",
+      confusions: [
+        { word: "prescribe", definition: "v. 开药方；规定" }
+      ]
+    },
+    {
+      word: "obviate",
+      definition: "v. 排除；使无必要",
+      phonetic: "ˈɑːbvieɪt",
+      example: "Consistent practice obviates last-minute cramming.",
+      confusions: [
+        { word: "deviate", definition: "v. 偏离；背离" }
+      ]
+    },
+    {
+      word: "ephemeral",
+      definition: "adj. 短暂的；转瞬即逝的",
+      phonetic: "ɪˈfemərəl",
+      example: "Ephemeral memory fades quickly without review.",
+      confusions: [
+        { word: "eternal", definition: "adj. 永恒的" }
+      ]
+    },
+    {
+      word: "vociferous",
+      definition: "adj. 喧哗的；大声疾呼的",
+      phonetic: "voʊˈsɪfərəs",
+      example: "Vociferous critics demanded a better syllabus.",
+      confusions: [
+        { word: "voracious", definition: "adj. 贪吃的；求知欲强的" }
+      ]
+    },
+    {
+      word: "recalcitrant",
+      definition: "adj. 桀骜不驯的；顽抗的",
+      phonetic: "rɪˈkælsɪtrənt",
+      example: "A recalcitrant habit resists sudden change.",
+      confusions: [
+        { word: "reticent", definition: "adj. 寡言少语的；不愿透露的" }
+      ]
+    },
+    {
+      word: "pellucid",
+      definition: "adj. 清澈的；清晰易懂的",
+      phonetic: "pəˈluːsɪd",
+      example: "Her pellucid explanation clarified the theory.",
+      confusions: [
+        { word: "recondite", definition: "adj. 深奥的；难懂的" }
+      ]
+    },
+    {
+      word: "sedulous",
+      definition: "adj. 勤奋的；刻苦的",
+      phonetic: "ˈsedʒələs",
+      example: "Sedulous effort eventually pays off in vocabulary building.",
+      confusions: [
+        { word: "seditious", definition: "adj. 煽动性的；闹革命的" }
+      ]
+    },
+    {
+      word: "castigate",
+      definition: "v. 严厉批评；惩罚",
+      phonetic: "ˈkæstɪɡeɪt",
+      example: "The professor castigated plagiarism harshly.",
+      confusions: [
+        { word: "extol", definition: "v. 赞美；颂扬" }
+      ]
+    }
+  ]
+};
+
+const EB_INTERVALS = [
+  0,
+  5 * 60 * 1000,
+  30 * 60 * 1000,
+  12 * 60 * 60 * 1000,
+  24 * 60 * 60 * 1000,
+  48 * 60 * 60 * 1000,
+  96 * 60 * 60 * 1000,
+  168 * 60 * 60 * 1000
+];
+
+const EB_STAGE_LABELS = [
+  "初识",
+  "5 分钟",
+  "30 分钟",
+  "12 小时",
+  "1 天",
+  "2 天",
+  "4 天",
+  "7 天"
+];
+
+const REVIEW_STORAGE_KEY = "vocab-review-schedule";
+
+const wordPackSelect = document.querySelector("#word-pack");
+const shuffleBtn = document.querySelector("#shuffle");
+const resetReviewBtn = document.querySelector("#reset-review");
+const showDefinitionBtn = document.querySelector("#show-definition");
+const markRememberedBtn = document.querySelector("#mark-remembered");
+const nextWordBtn = document.querySelector("#next-word");
+const wordElement = document.querySelector("#word");
+const phoneticElement = document.querySelector("#phonetic");
+const definitionElement = document.querySelector("#definition");
+const exampleElement = document.querySelector("#example");
+const hintsElement = document.querySelector("#confusion-hints");
+const progressCount = document.querySelector("#progress-count");
+const totalCount = document.querySelector("#total-count");
+const dueCountElement = document.querySelector("#due-count");
+const progressFill = document.querySelector("#progress-fill");
+const wordListElement = document.querySelector("#word-list");
+const reviewListElement = document.querySelector("#review-list");
+
+const spellingDefinitionElement = document.querySelector("#spelling-definition");
+const spellingPhoneticElement = document.querySelector("#spelling-phonetic");
+const spellingInput = document.querySelector("#spelling-input");
+const spellingCheckBtn = document.querySelector("#spelling-check");
+const spellingFeedback = document.querySelector("#spelling-feedback");
+const spellingNextBtn = document.querySelector("#spelling-next");
+
+const confusionDefinitionElement = document.querySelector("#confusion-definition");
+const confusionTipElement = document.querySelector("#confusion-tip");
+const confusionOptionsContainer = document.querySelector("#confusion-options");
+const confusionFeedback = document.querySelector("#confusion-feedback");
+const confusionNextBtn = document.querySelector("#confusion-next");
+
+const modeButtons = document.querySelectorAll(".mode-button");
+const modePanels = document.querySelectorAll("[data-mode-panel]");
+
+let currentPackName = "";
+let currentPack = [];
+let currentIndex = 0;
+let rememberedSet = new Set();
+let spellingWord = null;
+let confusionQuestion = null;
+let currentMode = "flashcard";
+let reviewSchedule = loadReviewData();
+
+function initWordPacks() {
+  Object.keys(WORD_PACKS).forEach((packName, index) => {
+    const option = document.createElement("option");
+    option.value = packName;
+    option.textContent = `${packName}（${WORD_PACKS[packName].length} 词）`;
+    if (index === 0) option.selected = true;
+    wordPackSelect.appendChild(option);
+  });
+
+  loadPack(wordPackSelect.value);
+}
+
+function loadPack(packName) {
+  currentPackName = packName;
+  currentPack = WORD_PACKS[packName].map((item) => ({ ...item }));
+  currentIndex = 0;
+  rememberedSet = new Set(
+    getCurrentPackReviews()
+      .filter((entry) => entry.stage > 0)
+      .map((entry) => entry.word)
+  );
+  totalCount.textContent = currentPack.length;
+  updateProgress();
+  renderWordList();
+  renderReviewPlan();
+  displayCurrentWord();
+  if (currentMode === "spelling") {
+    prepareSpellingPrompt();
+  }
+  if (currentMode === "confusion") {
+    prepareConfusionPrompt();
+  }
+}
+
+function shufflePack() {
+  for (let i = currentPack.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [currentPack[i], currentPack[j]] = [currentPack[j], currentPack[i]];
+  }
+  currentIndex = 0;
+  displayCurrentWord();
+  renderWordList();
+  if (currentMode === "spelling") {
+    prepareSpellingPrompt();
+  }
+  if (currentMode === "confusion") {
+    prepareConfusionPrompt();
+  }
+}
+
+function displayCurrentWord() {
+  if (!currentPack.length) {
+    wordElement.textContent = "词库为空";
+    phoneticElement.textContent = "";
+    definitionElement.textContent = "请选择其他词库";
+    exampleElement.textContent = "";
+    hintsElement.innerHTML = "";
+    return;
+  }
+
+  const current = currentPack[currentIndex];
+  wordElement.textContent = current.word;
+  phoneticElement.textContent = current.phonetic || "";
+  definitionElement.textContent = "点击“显示释义”查看";
+  exampleElement.textContent = "";
+  hintsElement.innerHTML = "";
+  showDefinitionBtn.disabled = false;
+}
+
+function showDefinition() {
+  const current = currentPack[currentIndex];
+  definitionElement.textContent = current.definition;
+  exampleElement.textContent = current.example || "";
+  hintsElement.innerHTML = "";
+  if (current.confusions && current.confusions.length) {
+    current.confusions.forEach((item) => {
+      const span = document.createElement("span");
+      span.textContent = `${item.word}：${item.definition}`;
+      hintsElement.appendChild(span);
+    });
+  }
+  showDefinitionBtn.disabled = true;
+}
+
+function nextWord() {
+  if (!currentPack.length) return;
+  currentIndex = (currentIndex + 1) % currentPack.length;
+  displayCurrentWord();
+}
+
+function markRemembered() {
+  if (!currentPack.length) return;
+  const current = currentPack[currentIndex];
+  handleSuccessfulReview(current);
+  nextWord();
+}
+
+function prepareSpellingPrompt() {
+  spellingFeedback.textContent = "";
+  spellingFeedback.className = "feedback";
+  spellingInput.value = "";
+  if (!currentPack.length) {
+    spellingDefinitionElement.textContent = "暂无单词";
+    spellingPhoneticElement.textContent = "";
+    spellingWord = null;
+    return;
+  }
+  spellingWord = pickRandom(currentPack);
+  spellingDefinitionElement.textContent = spellingWord.definition;
+  spellingPhoneticElement.textContent = spellingWord.phonetic || "";
+  spellingInput.focus();
+}
+
+function handleSpellingCheck() {
+  if (!spellingWord) return;
+  const answer = spellingInput.value.trim();
+  if (!answer) {
+    spellingFeedback.textContent = "请输入拼写再检查。";
+    spellingFeedback.className = "feedback";
+    return;
+  }
+  if (answer.toLowerCase() === spellingWord.word.toLowerCase()) {
+    spellingFeedback.textContent = `✅ 正确！${spellingWord.word} 已安排下一次复习。`;
+    spellingFeedback.className = "feedback success";
+    handleSuccessfulReview(spellingWord);
+    setTimeout(() => {
+      prepareSpellingPrompt();
+    }, 1600);
+  } else {
+    spellingFeedback.textContent = `❌ 正确拼写是 ${spellingWord.word}。稍后将快速复习。`;
+    spellingFeedback.className = "feedback error";
+    penalizeReview(spellingWord);
+  }
+}
+
+function prepareConfusionPrompt() {
+  confusionFeedback.textContent = "";
+  confusionFeedback.className = "feedback";
+  confusionOptionsContainer.innerHTML = "";
+  confusionTipElement.textContent = "";
+  if (!currentPack.length) {
+    confusionDefinitionElement.textContent = "暂无单词";
+    confusionQuestion = null;
+    return;
+  }
+  const candidates = currentPack.filter(
+    (item) => Array.isArray(item.confusions) && item.confusions.length
+  );
+  if (!candidates.length) {
+    confusionDefinitionElement.textContent = "当前词库暂未配置形近词，试试其他练习模式吧。";
+    confusionQuestion = null;
+    return;
+  }
+  const entry = pickRandom(candidates);
+  const confusionOptions = [
+    { word: entry.word, definition: entry.definition, correct: true },
+    ...pickConfusionOptions(entry.confusions)
+  ];
+  shuffle(confusionOptions);
+  confusionDefinitionElement.textContent = entry.definition;
+  confusionTipElement.textContent = `常混淆词：${entry.confusions
+    .map((item) => item.word)
+    .join("、")}`;
+  confusionOptions.forEach((option) => {
+    const button = document.createElement("button");
+    button.dataset.word = option.word;
+    button.innerHTML = `<span>${option.word}</span><span>${option.definition}</span>`;
+    button.addEventListener("click", () => handleConfusionSelection(option, button));
+    confusionOptionsContainer.appendChild(button);
+  });
+  confusionQuestion = { entry };
+}
+
+function handleConfusionSelection(option, button) {
+  if (!confusionQuestion) return;
+  const { entry } = confusionQuestion;
+  const correctWord = entry.word;
+  const buttons = confusionOptionsContainer.querySelectorAll("button");
+  buttons.forEach((btn) => {
+    btn.disabled = true;
+    if (btn.dataset.word === correctWord) {
+      btn.classList.add("correct");
+    }
+  });
+  if (option.word === correctWord) {
+    button.classList.add("correct");
+    confusionFeedback.textContent = `✅ ${correctWord} 表示“${entry.definition}”。`;
+    confusionFeedback.className = "feedback success";
+    handleSuccessfulReview(entry);
+    confusionTipElement.textContent = entry.confusions
+      .map((item) => `${item.word}：${item.definition}`)
+      .join("；");
+  } else {
+    button.classList.add("incorrect");
+    confusionFeedback.textContent = `❌ ${option.word} 意为“${option.definition}”，正确答案是 ${correctWord}。`;
+    confusionFeedback.className = "feedback error";
+    confusionTipElement.textContent = entry.confusions
+      .map((item) => `${item.word}：${item.definition}`)
+      .join("；");
+    penalizeReview(entry);
+  }
+  setTimeout(() => {
+    prepareConfusionPrompt();
+  }, 2000);
+}
+
+function handleSuccessfulReview(entry) {
+  rememberedSet.add(entry.word);
+  scheduleNextReview(entry.word);
+  updateProgress();
+  renderWordList();
+}
+
+function scheduleNextReview(word) {
+  if (!currentPackName) return;
+  const key = getWordKey(currentPackName, word);
+  const existing = reviewSchedule[key] || {
+    pack: currentPackName,
+    word,
+    stage: 0,
+    history: []
+  };
+  const nextStage = Math.min(existing.stage + 1, EB_INTERVALS.length - 1);
+  const nextReview = Date.now() + EB_INTERVALS[nextStage];
+  reviewSchedule[key] = {
+    pack: currentPackName,
+    word,
+    stage: nextStage,
+    nextReview,
+    history: [...existing.history.slice(-4), { time: Date.now(), stage: nextStage }]
+  };
+  saveReviewData();
+  renderReviewPlan();
+}
+
+function penalizeReview(entry) {
+  if (!currentPackName) return;
+  const key = getWordKey(currentPackName, entry.word);
+  const existing = reviewSchedule[key];
+  const fallbackStage = existing ? Math.max(existing.stage - 1, 1) : 1;
+  const nextReview = Date.now() + EB_INTERVALS[fallbackStage];
+  reviewSchedule[key] = {
+    pack: currentPackName,
+    word: entry.word,
+    stage: fallbackStage,
+    nextReview,
+    history: existing
+      ? [...existing.history.slice(-4), { time: Date.now(), stage: fallbackStage, mistake: true }]
+      : [{ time: Date.now(), stage: fallbackStage, mistake: true }]
+  };
+  saveReviewData();
+  renderReviewPlan();
+  renderWordList();
+  updateProgress();
+}
+
+function updateProgress() {
+  const total = currentPack.length;
+  const remembered = Array.from(rememberedSet).filter((word) =>
+    currentPack.some((item) => item.word === word)
+  ).length;
+  progressCount.textContent = remembered;
+  totalCount.textContent = total;
+  const percent = total === 0 ? 0 : Math.round((remembered / total) * 100);
+  progressFill.style.width = `${percent}%`;
+  progressFill.setAttribute("aria-valuenow", percent);
+  updateDueCount();
+}
+
+function renderWordList() {
+  wordListElement.innerHTML = "";
+  if (!currentPack.length) {
+    const empty = document.createElement("li");
+    empty.textContent = "请选择词库开始练习。";
+    wordListElement.appendChild(empty);
+    return;
+  }
+  currentPack.forEach((item) => {
+    const li = document.createElement("li");
+    const header = document.createElement("div");
+    header.className = "word-item-header";
+    const wordSpan = document.createElement("span");
+    wordSpan.textContent = item.word;
+    header.appendChild(wordSpan);
+
+    const status = document.createElement("span");
+    status.className = "word-item-status";
+    const schedule = reviewSchedule[getWordKey(currentPackName, item.word)];
+    if (schedule && typeof schedule.nextReview === "number") {
+      const due = schedule.nextReview <= Date.now();
+      status.textContent = due ? "⚠️ 待复习" : `✅ ${EB_STAGE_LABELS[schedule.stage] || "巩固中"}`;
+      status.classList.add(due ? "due" : "mastered");
+    } else if (rememberedSet.has(item.word)) {
+      status.textContent = "✅ 巩固中";
+      status.classList.add("mastered");
+    } else {
+      status.textContent = "⏳ 待学习";
+    }
+    header.appendChild(status);
+
+    const definition = document.createElement("p");
+    definition.className = "word-item-definition";
+    definition.textContent = item.definition;
+
+    li.appendChild(header);
+    li.appendChild(definition);
+
+    const scheduleInfo = document.createElement("span");
+    scheduleInfo.className = "word-item-status";
+    if (schedule && typeof schedule.nextReview === "number") {
+      const dueText = formatRelativeTime(schedule.nextReview);
+      scheduleInfo.textContent = `下次复习：${formatDateTime(schedule.nextReview)}（${dueText}）`;
+      if (schedule.nextReview <= Date.now()) {
+        scheduleInfo.classList.add("due");
+      }
+    } else {
+      scheduleInfo.textContent = "完成一次练习后将生成复习计划。";
+    }
+    li.appendChild(scheduleInfo);
+
+    wordListElement.appendChild(li);
+  });
+}
+
+function renderReviewPlan() {
+  reviewListElement.innerHTML = "";
+  const entries = getCurrentPackReviews().sort(
+    (a, b) => (a.nextReview ?? Number.POSITIVE_INFINITY) - (b.nextReview ?? Number.POSITIVE_INFINITY)
+  );
+  if (!entries.length) {
+    const empty = document.createElement("li");
+    empty.textContent = "暂无复习记录，先完成一次练习吧！";
+    reviewListElement.appendChild(empty);
+    updateDueCount();
+    return;
+  }
+  entries.forEach((entry) => {
+    const li = document.createElement("li");
+    if (typeof entry.nextReview === "number" && entry.nextReview <= Date.now()) {
+      li.classList.add("due");
+    }
+    const header = document.createElement("div");
+    header.className = "word-item-header";
+    const wordSpan = document.createElement("span");
+    wordSpan.textContent = entry.word;
+    const stageSpan = document.createElement("span");
+    stageSpan.className = "word-item-status";
+    stageSpan.textContent = `阶段：${EB_STAGE_LABELS[entry.stage] || "巩固"}`;
+    if (typeof entry.nextReview === "number" && entry.nextReview <= Date.now()) {
+      stageSpan.classList.add("due");
+    } else {
+      stageSpan.classList.add("mastered");
+    }
+    header.append(wordSpan, stageSpan);
+
+    const meta = document.createElement("div");
+    meta.className = "meta";
+    if (typeof entry.nextReview === "number") {
+      meta.textContent = `下次复习：${formatDateTime(entry.nextReview)}（${formatRelativeTime(entry.nextReview)}）`;
+    } else {
+      meta.textContent = "复习时间待更新";
+    }
+
+    const streak = document.createElement("div");
+    streak.className = "meta";
+    const history = Array.isArray(entry.history) && entry.history.length ? entry.history : [{ stage: entry.stage }];
+    streak.textContent = `已完成阶段：${history
+      .map((item) => EB_STAGE_LABELS[item.stage] || item.stage)
+      .join(" → ")}`;
+
+    li.append(header, meta, streak);
+    reviewListElement.appendChild(li);
+  });
+  updateDueCount();
+}
+
+function updateDueCount() {
+  const entries = getCurrentPackReviews();
+  const due = entries.filter((entry) => typeof entry.nextReview === "number" && entry.nextReview <= Date.now()).length;
+  if (dueCountElement) {
+    dueCountElement.textContent = `${due} 个待复习`;
+  }
+}
+
+function getCurrentPackReviews() {
+  return Object.values(reviewSchedule).filter((entry) => entry.pack === currentPackName);
+}
+
+function loadReviewData() {
+  try {
+    const raw = localStorage.getItem(REVIEW_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (error) {
+    console.warn("无法读取复习数据：", error);
+    return {};
+  }
+}
+
+function saveReviewData() {
+  try {
+    localStorage.setItem(REVIEW_STORAGE_KEY, JSON.stringify(reviewSchedule));
+  } catch (error) {
+    console.warn("无法保存复习数据：", error);
+  }
+}
+
+function pickRandom(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function shuffle(list) {
+  for (let i = list.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [list[i], list[j]] = [list[j], list[i]];
+  }
+  return list;
+}
+
+function pickConfusionOptions(confusions) {
+  const clones = [...confusions];
+  shuffle(clones);
+  return clones.slice(0, Math.min(2, clones.length)).map((item) => ({
+    word: item.word,
+    definition: item.definition,
+    correct: false
+  }));
+}
+
+function formatRelativeTime(timestamp) {
+  const diff = timestamp - Date.now();
+  const absDiff = Math.abs(diff);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (absDiff < minute) {
+    return diff < 0 ? "刚刚过期" : "即将到来";
+  }
+  if (absDiff < hour) {
+    const value = Math.round(absDiff / minute);
+    return diff < 0 ? `${value} 分钟前` : `${value} 分钟后`;
+  }
+  if (absDiff < day) {
+    const value = Math.round(absDiff / hour);
+    return diff < 0 ? `${value} 小时前` : `${value} 小时后`;
+  }
+  const value = Math.round(absDiff / day);
+  return diff < 0 ? `${value} 天前` : `${value} 天后`;
+}
+
+function formatDateTime(timestamp) {
+  const date = new Date(timestamp);
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  const hours = `${date.getHours()}`.padStart(2, "0");
+  const minutes = `${date.getMinutes()}`.padStart(2, "0");
+  return `${month}/${day} ${hours}:${minutes}`;
+}
+
+function getWordKey(packName, word) {
+  return `${packName}::${word}`;
+}
+
+function resetCurrentPackReview() {
+  if (!currentPackName) return;
+  const confirmReset = window.confirm(`确认清除“${currentPackName}”的复习记录吗？`);
+  if (!confirmReset) return;
+  Object.keys(reviewSchedule).forEach((key) => {
+    if (reviewSchedule[key].pack === currentPackName) {
+      delete reviewSchedule[key];
+    }
+  });
+  saveReviewData();
+  loadPack(currentPackName);
+}
+
+function switchMode(mode) {
+  currentMode = mode;
+  modeButtons.forEach((button) => {
+    button.classList.toggle("active", button.dataset.mode === mode);
+  });
+  modePanels.forEach((panel) => {
+    panel.hidden = panel.dataset.modePanel !== mode;
+  });
+  if (mode === "spelling") {
+    prepareSpellingPrompt();
+  }
+  if (mode === "confusion") {
+    prepareConfusionPrompt();
+  }
+}
+
+wordPackSelect.addEventListener("change", (event) => {
+  loadPack(event.target.value);
+});
+
+shuffleBtn.addEventListener("click", () => {
+  shufflePack();
+});
+
+resetReviewBtn.addEventListener("click", () => {
+  resetCurrentPackReview();
+});
+
+showDefinitionBtn.addEventListener("click", () => {
+  showDefinition();
+});
+
+nextWordBtn.addEventListener("click", () => {
+  nextWord();
+});
+
+markRememberedBtn.addEventListener("click", () => {
+  markRemembered();
+});
+
+spellingCheckBtn.addEventListener("click", () => {
+  handleSpellingCheck();
+});
+
+spellingInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    handleSpellingCheck();
+  }
+});
+
+spellingNextBtn.addEventListener("click", () => {
+  prepareSpellingPrompt();
+});
+
+confusionNextBtn.addEventListener("click", () => {
+  prepareConfusionPrompt();
+});
+
+modeButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    switchMode(button.dataset.mode);
+  });
+});
+
+setInterval(() => {
+  renderReviewPlan();
+  renderWordList();
+  updateProgress();
+}, 60 * 1000);
+
+initWordPacks();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,492 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f6fb;
+  --bg-card: #ffffff;
+  --bg-dark: #131722;
+  --bg-card-dark: #1e2333;
+  --text: #1f2430;
+  --text-muted: #5f6a7d;
+  --accent: #4169e1;
+  --accent-light: rgba(65, 105, 225, 0.1);
+  --success: #23a559;
+  --warning: #e39c1f;
+  --danger: #d9534f;
+  --border: rgba(31, 36, 48, 0.12);
+  --shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  --radius-lg: 20px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: var(--bg-dark);
+    --bg-card: var(--bg-card-dark);
+    --text: #e5eaf5;
+    --text-muted: #8c95a8;
+    --accent-light: rgba(65, 105, 225, 0.2);
+    --border: rgba(229, 234, 245, 0.08);
+    --shadow: 0 16px 40px rgba(7, 11, 23, 0.45);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "PingFang SC", "Microsoft YaHei", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top left, rgba(65, 105, 225, 0.1), transparent 55%),
+    radial-gradient(circle at 25% 90%, rgba(35, 165, 89, 0.12), transparent 50%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.app-header {
+  text-align: center;
+  padding: 48px 16px 24px;
+  position: relative;
+}
+
+.app-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(65, 105, 225, 0.14), transparent 65%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 5vw, 2.6rem);
+  margin-bottom: 8px;
+  letter-spacing: 0.04em;
+}
+
+.app-header p {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.app-main {
+  width: min(1080px, 94vw);
+  margin: 0 auto 56px;
+  display: grid;
+  gap: 24px;
+}
+
+.controls,
+.mode-selector,
+.mode-panel,
+.progress,
+.review-plan,
+.word-list {
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(10px);
+  border-radius: var(--radius-lg);
+  padding: 20px 24px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+@media (prefers-color-scheme: dark) {
+  .controls,
+  .mode-selector,
+  .mode-panel,
+  .progress,
+  .review-plan,
+  .word-list {
+    background: rgba(30, 35, 51, 0.86);
+  }
+}
+
+.controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.control-group {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+select,
+button,
+input[type="text"] {
+  font: inherit;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  padding: 10px 16px;
+  background: rgba(255, 255, 255, 0.86);
+  color: inherit;
+  transition: border 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  select,
+  button,
+  input[type="text"] {
+    background: rgba(19, 23, 34, 0.7);
+  }
+}
+
+select:focus,
+input[type="text"]:focus,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.primary:hover {
+  box-shadow: 0 12px 24px rgba(65, 105, 225, 0.25);
+}
+
+.secondary {
+  background: rgba(65, 105, 225, 0.08);
+  color: var(--accent);
+}
+
+.success {
+  background: var(--success);
+  color: #fff;
+}
+
+.ghost {
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--text-muted);
+}
+
+.mode-selector {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.mode-button {
+  flex: 1;
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: rgba(65, 105, 225, 0.08);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.mode-button.active {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(65, 105, 225, 0.3);
+}
+
+.mode-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel-header h2 {
+  margin: 0 0 6px;
+  font-size: 1.25rem;
+}
+
+.panel-header p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.flashcard {
+  display: grid;
+  gap: 12px;
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(65, 105, 225, 0.12), rgba(255, 255, 255, 0.6));
+}
+
+.flashcard-front,
+.flashcard-back {
+  display: grid;
+  gap: 6px;
+}
+
+.label {
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.content {
+  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.phonetic {
+  font-size: 1rem;
+  color: var(--accent);
+  margin: 0;
+}
+
+.example {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin: 4px 0 0;
+  line-height: 1.5;
+}
+
+.hints {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.hints span {
+  font-size: 0.85rem;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(35, 165, 89, 0.12);
+  color: var(--success);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.action-group {
+  display: flex;
+  gap: 12px;
+}
+
+.input-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.input-group input[type="text"] {
+  min-width: 220px;
+}
+
+.feedback {
+  min-height: 24px;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.feedback.success {
+  color: var(--success);
+}
+
+.feedback.error {
+  color: var(--danger);
+}
+
+.option-list {
+  display: grid;
+  gap: 12px;
+}
+
+.option-list button {
+  justify-content: space-between;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.option-list button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(65, 105, 225, 0.14);
+}
+
+.option-list button.correct {
+  border-color: var(--success);
+  background: rgba(35, 165, 89, 0.12);
+  color: var(--success);
+}
+
+.option-list button.incorrect {
+  border-color: var(--danger);
+  background: rgba(217, 83, 79, 0.12);
+  color: var(--danger);
+}
+
+.tip {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.progress {
+  display: grid;
+  gap: 12px;
+}
+
+.progress-text {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.due-count {
+  color: var(--warning);
+}
+
+.progress-bar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(65, 105, 225, 0.14);
+  overflow: hidden;
+}
+
+#progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #7c9bff, #4169e1);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.review-plan ul,
+.word-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.review-plan li,
+.word-list li {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.review-plan li.due {
+  border-color: var(--warning);
+  background: rgba(227, 156, 31, 0.12);
+}
+
+.review-plan .meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.word-item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.word-item-header span {
+  font-weight: 600;
+}
+
+.word-item-status {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.word-item-status.due {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.word-item-status.mastered {
+  color: var(--success);
+}
+
+.word-item-definition {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.app-footer {
+  text-align: center;
+  padding: 32px 16px 48px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    gap: 18px;
+  }
+
+  .controls,
+  .mode-selector,
+  .mode-panel,
+  .progress,
+  .review-plan,
+  .word-list {
+    padding: 18px;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .action-group,
+  .input-group {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .mode-selector {
+    flex-direction: column;
+  }
+
+  .mode-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the study page with mode selector, spaced review progress, and review plan callouts
- refresh styling with glassy cards, dark mode support, and responsive layout for new panels
- implement Kaoyan & GRE word packs, Ebbinghaus-based scheduling, spelling and confusion practice workflows with review data persistence

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d75ed88bf0832bb5db193edff8c474