### PR TITLE
Rebuild vocabulary trainer with Baicizhan-style staged drills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>记忆冲刺｜背单词训练营</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="top-bar" aria-label="批次与词库设置">
+      <div class="brand">
+        <span class="brand-logo" aria-hidden="true">⚡</span>
+        <div>
+          <h1>记忆冲刺</h1>
+          <p>参考百词斩节奏，10 词一组多题型巩固</p>
+        </div>
+      </div>
+      <div class="top-controls">
+        <label class="field">
+          <span>选择词库</span>
+          <select id="word-pack" aria-label="选择词库"></select>
+        </label>
+        <button id="prev-batch" class="ghost" type="button">上一组</button>
+        <button id="next-batch" class="ghost" type="button">下一组</button>
+      </div>
+      <div class="session-status">
+        <p><strong id="batch-title">第 1 组</strong></p>
+        <p id="batch-progress">0 / 0 完成</p>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <section class="practice-zone" aria-live="polite">
+        <article class="practice-card" id="practice-card">
+          <header class="card-header">
+            <span id="stage-pill" class="stage-pill">选择释义</span>
+            <div class="stage-tracker" id="stage-tracker" aria-label="本词训练阶段进度"></div>
+            <div class="card-progress">
+              <span id="word-counter">0 / 0</span>
+            </div>
+          </header>
+          <div class="card-hero">
+            <div class="hero-word">
+              <p class="hero-label">当前单词</p>
+              <h2 id="word-text">请选择词库</h2>
+              <p id="phonetic-text" class="hero-phonetic"></p>
+            </div>
+            <div class="hero-meta">
+              <p id="stage-title">请选择词库开始训练</p>
+              <p id="stage-description" class="stage-description"></p>
+            </div>
+          </div>
+          <div class="card-body">
+            <div id="choice-area" class="choice-grid" role="group" aria-label="释义选项"></div>
+            <div id="tf-area" class="tf-actions" hidden>
+              <button id="btn-true" type="button" class="action primary">正确</button>
+              <button id="btn-false" type="button" class="action danger">错误</button>
+            </div>
+            <div id="spelling-area" class="spelling-box" hidden>
+              <label for="spell-input">请输入单词拼写</label>
+              <div class="spelling-input">
+                <input id="spell-input" type="text" autocomplete="off" spellcheck="false" />
+                <button id="spell-submit" type="button" class="action primary">提交</button>
+              </div>
+            </div>
+            <p id="feedback" class="feedback" role="status"></p>
+          </div>
+          <footer class="card-footer">
+            <button id="replay-word" class="ghost" type="button">再看一次释义</button>
+            <button id="skip-word" class="ghost" type="button">换个单词</button>
+          </footer>
+        </article>
+      </section>
+
+      <aside class="side-panel" aria-label="批次进度与待巩固">
+        <section class="summary">
+          <h2>本组词汇</h2>
+          <ul id="word-list" class="word-list"></ul>
+        </section>
+        <section class="summary">
+          <h2>错题回顾</h2>
+          <ul id="mistake-list" class="mistake-list"></ul>
+        </section>
+        <section class="summary info">
+          <h2>学习节奏</h2>
+          <ol>
+            <li>形近辨析：在多个释义里选出正确项。</li>
+            <li>释义判断：快速判断对错，强化语义映射。</li>
+            <li>拼写回忆：闭眼默写，完成从识记到输出。</li>
+          </ol>
+        </section>
+      </aside>
+    </main>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,680 @@
+const WORD_PACKS = {
+  "考研词汇": [
+    {
+      word: "ameliorate",
+      definition: "v. 改善；使好转",
+      phonetic: "əˈmiːliəreɪt",
+      example: "A well-structured review plan can ameliorate exam anxiety.",
+      confusions: [
+        { word: "deteriorate", definition: "v. 恶化；退化" },
+        { word: "alleviate", definition: "v. 缓解；减轻" }
+      ]
+    },
+    {
+      word: "meticulous",
+      definition: "adj. 一丝不苟的；严谨的",
+      phonetic: "məˈtɪkjələs",
+      example: "She kept meticulous notes of every practice test.",
+      confusions: [{ word: "fastidious", definition: "adj. 挑剔的；极其注意细节的" }]
+    },
+    {
+      word: "exacerbate",
+      definition: "v. 使恶化；使加剧",
+      phonetic: "ɪɡˈzæsəbeɪt",
+      example: "Skipping reviews will exacerbate the forgetting problem.",
+      confusions: [{ word: "exasperate", definition: "v. 激怒；使恼怒" }]
+    },
+    {
+      word: "pragmatic",
+      definition: "adj. 务实的；讲求实际的",
+      phonetic: "præɡˈmætɪk",
+      example: "A pragmatic learner blends flashcards with writing practice.",
+      confusions: [{ word: "dogmatic", definition: "adj. 教条的；武断的" }]
+    },
+    {
+      word: "delineate",
+      definition: "v. 描述；勾画轮廓",
+      phonetic: "dɪˈlɪnieɪt",
+      example: "The teacher delineated the key grammar points in detail.",
+      confusions: [{ word: "eliminate", definition: "v. 消除；淘汰" }]
+    },
+    {
+      word: "ubiquitous",
+      definition: "adj. 无处不在的；普遍存在的",
+      phonetic: "juːˈbɪkwɪtəs",
+      example: "Mobile apps make ubiquitous learning possible.",
+      confusions: [{ word: "unique", definition: "adj. 独一无二的" }]
+    },
+    {
+      word: "pertinent",
+      definition: "adj. 相关的；中肯的",
+      phonetic: "ˈpɜːrtɪnənt",
+      example: "Only pertinent examples are kept in the final notes.",
+      confusions: [{ word: "impertinent", definition: "adj. 无礼的；不相关的" }]
+    },
+    {
+      word: "alleviate",
+      definition: "v. 缓解；减轻",
+      phonetic: "əˈliːvieɪt",
+      example: "Regular breaks can alleviate fatigue during revision.",
+      confusions: [{ word: "aggravate", definition: "v. 加重；恶化" }]
+    },
+    {
+      word: "galvanize",
+      definition: "v. 激励；通电镀锌",
+      phonetic: "ˈɡælvənaɪz",
+      example: "The looming exam date galvanized her to study harder.",
+      confusions: [{ word: "paralyze", definition: "v. 使瘫痪；使麻痹" }]
+    },
+    {
+      word: "consolidate",
+      definition: "v. 巩固；合并",
+      phonetic: "kənˈsɑːlɪdeɪt",
+      example: "Daily review consolidates long-term memory.",
+      confusions: [{ word: "liquidate", definition: "v. 清算；变现" }]
+    }
+  ],
+  "GRE词汇": [
+    {
+      word: "abrogate",
+      definition: "v. 废除；撤销",
+      phonetic: "ˈæbrəɡeɪt",
+      example: "The committee voted to abrogate the outdated rule.",
+      confusions: [{ word: "arrogate", definition: "v. 冒称拥有；霸占" }]
+    },
+    {
+      word: "intransigent",
+      definition: "adj. 不妥协的；固执的",
+      phonetic: "ɪnˈtrænsɪdʒənt",
+      example: "The negotiator faced an intransigent opponent.",
+      confusions: [{ word: "insurgent", definition: "n. 叛乱者；起义者" }]
+    },
+    {
+      word: "proscribe",
+      definition: "v. 禁止；取缔",
+      phonetic: "proʊˈskraɪb",
+      example: "The policy proscribed the use of informal sources.",
+      confusions: [{ word: "prescribe", definition: "v. 开药方；规定" }]
+    },
+    {
+      word: "obviate",
+      definition: "v. 排除；使无必要",
+      phonetic: "ˈɑːbvieɪt",
+      example: "Consistent practice obviates last-minute cramming.",
+      confusions: [{ word: "deviate", definition: "v. 偏离；背离" }]
+    },
+    {
+      word: "ephemeral",
+      definition: "adj. 短暂的；转瞬即逝的",
+      phonetic: "ɪˈfemərəl",
+      example: "Ephemeral memory fades quickly without review.",
+      confusions: [{ word: "eternal", definition: "adj. 永恒的" }]
+    },
+    {
+      word: "vociferous",
+      definition: "adj. 喧哗的；大声疾呼的",
+      phonetic: "voʊˈsɪfərəs",
+      example: "Vociferous critics demanded a better syllabus.",
+      confusions: [{ word: "voracious", definition: "adj. 贪吃的；求知欲强的" }]
+    },
+    {
+      word: "recalcitrant",
+      definition: "adj. 桀骜不驯的；顽抗的",
+      phonetic: "rɪˈkælsɪtrənt",
+      example: "A recalcitrant habit resists sudden change.",
+      confusions: [{ word: "reticent", definition: "adj. 寡言少语的；不愿透露的" }]
+    },
+    {
+      word: "pellucid",
+      definition: "adj. 清澈的；清晰易懂的",
+      phonetic: "pəˈluːsɪd",
+      example: "Her pellucid explanation clarified the theory.",
+      confusions: [{ word: "recondite", definition: "adj. 深奥的；难懂的" }]
+    },
+    {
+      word: "sedulous",
+      definition: "adj. 勤奋的；刻苦的",
+      phonetic: "ˈsedʒələs",
+      example: "Sedulous effort eventually pays off in vocabulary building.",
+      confusions: [{ word: "seditious", definition: "adj. 煽动性的；闹革命的" }]
+    },
+    {
+      word: "castigate",
+      definition: "v. 严厉批评；惩罚",
+      phonetic: "ˈkæstɪɡeɪt",
+      example: "The professor castigated plagiarism harshly.",
+      confusions: [{ word: "extol", definition: "v. 赞美；颂扬" }]
+    }
+  ]
+};
+
+const PRACTICE_STAGES = [
+  {
+    id: "choice",
+    pill: "形近辨析",
+    title: "形近词释义选择",
+    description: "从多个形近词释义中选出与本词匹配的一项，强化辨析力。"
+  },
+  {
+    id: "judge",
+    pill: "释义判断",
+    title: "释义判断",
+    description: "判断给出的释义是否对应当前单词，提升语义反应速度。"
+  },
+  {
+    id: "spelling",
+    pill: "拼写回忆",
+    title: "拼写回忆",
+    description: "根据释义拼写单词，完成从识记到输出的闭环。"
+  }
+];
+
+const BATCH_SIZE = 10;
+
+const state = {
+  packName: "",
+  packWords: [],
+  batchIndex: 0,
+  batchCount: 0,
+  sessionWords: [],
+  queue: [],
+  current: null,
+  locked: false,
+  prompt: null,
+  mistakes: new Map()
+};
+
+const elements = {};
+
+document.addEventListener("DOMContentLoaded", () => {
+  cacheElements();
+  bindEvents();
+  initPackOptions();
+});
+
+function cacheElements() {
+  elements.packSelect = document.getElementById("word-pack");
+  elements.prevBatch = document.getElementById("prev-batch");
+  elements.nextBatch = document.getElementById("next-batch");
+  elements.batchTitle = document.getElementById("batch-title");
+  elements.batchProgress = document.getElementById("batch-progress");
+  elements.wordCounter = document.getElementById("word-counter");
+  elements.stagePill = document.getElementById("stage-pill");
+  elements.stageTracker = document.getElementById("stage-tracker");
+  elements.wordText = document.getElementById("word-text");
+  elements.phoneticText = document.getElementById("phonetic-text");
+  elements.stageTitle = document.getElementById("stage-title");
+  elements.stageDescription = document.getElementById("stage-description");
+  elements.choiceArea = document.getElementById("choice-area");
+  elements.tfArea = document.getElementById("tf-area");
+  elements.btnTrue = document.getElementById("btn-true");
+  elements.btnFalse = document.getElementById("btn-false");
+  elements.spellingArea = document.getElementById("spelling-area");
+  elements.spellInput = document.getElementById("spell-input");
+  elements.spellSubmit = document.getElementById("spell-submit");
+  elements.feedback = document.getElementById("feedback");
+  elements.replay = document.getElementById("replay-word");
+  elements.skip = document.getElementById("skip-word");
+  elements.wordList = document.getElementById("word-list");
+  elements.mistakeList = document.getElementById("mistake-list");
+}
+
+function bindEvents() {
+  elements.packSelect.addEventListener("change", () => {
+    const name = elements.packSelect.value;
+    preparePack(name);
+  });
+
+  elements.prevBatch.addEventListener("click", () => {
+    if (state.batchIndex > 0) {
+      startBatch(state.batchIndex - 1);
+    }
+  });
+
+  elements.nextBatch.addEventListener("click", () => {
+    if (state.batchIndex < state.batchCount - 1) {
+      startBatch(state.batchIndex + 1);
+    }
+  });
+
+  elements.btnTrue.addEventListener("click", () => handleJudgeAnswer(true));
+  elements.btnFalse.addEventListener("click", () => handleJudgeAnswer(false));
+  elements.spellSubmit.addEventListener("click", () => handleSpellingSubmit());
+  elements.spellInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSpellingSubmit();
+    }
+  });
+
+  elements.replay.addEventListener("click", showDefinitionHint);
+  elements.skip.addEventListener("click", skipCurrentWord);
+}
+
+function initPackOptions() {
+  const fragment = document.createDocumentFragment();
+  Object.keys(WORD_PACKS).forEach((name) => {
+    const option = document.createElement("option");
+    option.value = name;
+    option.textContent = name;
+    fragment.appendChild(option);
+  });
+  elements.packSelect.appendChild(fragment);
+  const firstPack = Object.keys(WORD_PACKS)[0];
+  elements.packSelect.value = firstPack;
+  preparePack(firstPack);
+}
+
+function preparePack(name) {
+  state.packName = name;
+  const rawWords = WORD_PACKS[name] ?? [];
+  state.packWords = rawWords.map((item, index) => ({
+    ...item,
+    id: `${name}-${index}`
+  }));
+  state.batchCount = Math.max(1, Math.ceil(state.packWords.length / BATCH_SIZE));
+  startBatch(0);
+}
+
+function startBatch(batchIndex) {
+  state.batchIndex = batchIndex;
+  state.mistakes.clear();
+  const start = batchIndex * BATCH_SIZE;
+  const slice = state.packWords.slice(start, start + BATCH_SIZE);
+  state.sessionWords = slice.map((item, index) => ({
+    id: `${item.id}-${batchIndex}-${index}`,
+    word: item.word,
+    definition: item.definition,
+    phonetic: item.phonetic ?? "",
+    example: item.example ?? "",
+    confusions: Array.isArray(item.confusions) ? [...item.confusions] : [],
+    stage: 0,
+    mistakes: 0
+  }));
+  state.queue = state.sessionWords.slice();
+  shuffleArray(state.queue);
+  state.current = state.queue.shift() ?? null;
+  state.locked = false;
+  state.prompt = null;
+  updateBatchHeader();
+  renderCurrent();
+  updateWordList();
+  updateMistakeList();
+  updateBatchButtons();
+}
+
+function updateBatchButtons() {
+  elements.prevBatch.disabled = state.batchIndex <= 0;
+  elements.nextBatch.disabled = state.batchIndex >= state.batchCount - 1;
+}
+
+function updateBatchHeader() {
+  const title = state.batchCount > 1 ? `第 ${state.batchIndex + 1} 组` : "本组词汇";
+  elements.batchTitle.textContent = title;
+  const finished = state.sessionWords.filter((word) => word.stage >= PRACTICE_STAGES.length).length;
+  const total = state.sessionWords.length;
+  elements.batchProgress.textContent = `${finished} / ${total} 完成`;
+}
+
+function renderCurrent() {
+  const { current } = state;
+  const total = state.sessionWords.length;
+  const finished = state.sessionWords.filter((word) => word.stage >= PRACTICE_STAGES.length).length;
+
+  if (!current) {
+    elements.stagePill.textContent = "全部完成";
+    elements.stageTracker.innerHTML = "";
+    elements.wordText.textContent = total ? "本组已通关" : "暂无单词";
+    elements.phoneticText.textContent = "";
+    elements.stageTitle.textContent = total ? "干得漂亮！" : "请先添加词库";
+    elements.stageDescription.textContent = total
+      ? "可以切换下一组或重新开始巩固错词。"
+      : "选择包含单词的词库开始训练。";
+    elements.choiceArea.innerHTML = "";
+    elements.tfArea.hidden = true;
+    elements.spellingArea.hidden = true;
+    elements.feedback.textContent = total
+      ? "错题已加入右侧列表，随时复盘。"
+      : "";
+    elements.wordCounter.textContent = `${finished} / ${total}`;
+    elements.skip.disabled = true;
+    return;
+  }
+
+  const stage = PRACTICE_STAGES[current.stage];
+  elements.stagePill.textContent = stage.pill;
+  elements.stageTitle.textContent = stage.title;
+  elements.stageDescription.textContent = stage.description;
+  elements.wordText.textContent = current.word;
+  elements.phoneticText.textContent = current.phonetic || "";
+  elements.feedback.textContent = "";
+  elements.wordCounter.textContent = `第 ${Math.min(finished + 1, total)} / ${total} 词`;
+
+  renderStageTracker(current.stage);
+
+  switch (stage.id) {
+    case "choice":
+      renderChoiceStage(current);
+      break;
+    case "judge":
+      renderJudgeStage(current);
+      break;
+    case "spelling":
+      renderSpellingStage(current);
+      break;
+    default:
+      break;
+  }
+
+  state.locked = false;
+  updateBatchHeader();
+  updateWordList();
+  elements.skip.disabled = state.queue.length === 0;
+}
+
+function renderStageTracker(activeIndex) {
+  elements.stageTracker.innerHTML = "";
+  PRACTICE_STAGES.forEach((stage, index) => {
+    const dot = document.createElement("span");
+    dot.className = "stage-dot";
+    if (index < activeIndex) {
+      dot.classList.add("completed");
+    } else if (index === activeIndex) {
+      dot.classList.add("active");
+    }
+    elements.stageTracker.appendChild(dot);
+  });
+}
+
+function renderChoiceStage(word) {
+  elements.choiceArea.hidden = false;
+  elements.tfArea.hidden = true;
+  elements.spellingArea.hidden = true;
+  elements.choiceArea.innerHTML = "";
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}`;
+
+  const options = buildChoiceOptions(word);
+  options.forEach((option) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "choice-button";
+    button.textContent = option.text;
+    button.dataset.correct = option.correct ? "true" : "false";
+    button.addEventListener("click", () => {
+      if (state.locked) return;
+      state.locked = true;
+      if (option.correct) {
+        button.classList.add("correct");
+        showFeedback("答对啦！继续下一关。", "success");
+        transitionAfterChoice(true);
+      } else {
+        button.classList.add("wrong");
+        highlightCorrectChoice();
+        recordMistake(word, "choice", option.text);
+        showFeedback("这不是本词释义，等会儿我们会再练一次。", "danger");
+        transitionAfterChoice(false);
+      }
+    });
+    elements.choiceArea.appendChild(button);
+  });
+}
+
+function transitionAfterChoice(correct) {
+  setTimeout(() => {
+    if (correct) {
+      advanceCurrentStage();
+    } else {
+      recycleCurrentWord();
+    }
+  }, 720);
+}
+
+function renderJudgeStage(word) {
+  elements.choiceArea.hidden = true;
+  elements.tfArea.hidden = false;
+  elements.spellingArea.hidden = true;
+
+  const isCorrect = Math.random() < 0.6;
+  const definition = isCorrect ? word.definition : pickDistractorDefinition(word);
+  state.prompt = {
+    stage: "judge",
+    isCorrect,
+    definition
+  };
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}<br><span class="definition-inline">释义：${definition}</span>`;
+}
+
+function handleJudgeAnswer(answer) {
+  if (state.locked || !state.current || !state.prompt || state.prompt.stage !== "judge") {
+    return;
+  }
+  state.locked = true;
+  const correct = answer === state.prompt.isCorrect;
+  if (correct) {
+    showFeedback("判断准确！往更高层次迈进。", "success");
+    setTimeout(() => advanceCurrentStage(), 640);
+  } else {
+    recordMistake(state.current, "judge", state.prompt.definition);
+    showFeedback("判断有误，稍后继续巩固。", "danger");
+    setTimeout(() => recycleCurrentWord(), 720);
+  }
+}
+
+function renderSpellingStage(word) {
+  elements.choiceArea.hidden = true;
+  elements.tfArea.hidden = true;
+  elements.spellingArea.hidden = false;
+  elements.spellInput.value = "";
+  try {
+    elements.spellInput.focus({ preventScroll: true });
+  } catch (error) {
+    elements.spellInput.focus();
+  }
+  state.prompt = {
+    stage: "spelling",
+    answer: word.word.toLowerCase()
+  };
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}<br><span class="definition-inline">释义：${word.definition}</span>`;
+}
+
+function handleSpellingSubmit() {
+  if (state.locked || !state.current || !state.prompt || state.prompt.stage !== "spelling") {
+    return;
+  }
+  const input = elements.spellInput.value.trim();
+  if (!input) {
+    showFeedback("先尝试拼写一下吧～", "warning");
+    return;
+  }
+  state.locked = true;
+  const answer = state.prompt.answer;
+  if (input.toLowerCase() === answer) {
+    showFeedback("太棒了！本词已完成所有练习。", "success");
+    setTimeout(() => advanceCurrentStage(), 640);
+  } else {
+    recordMistake(state.current, "spelling", input);
+    showFeedback(`正确拼写是 ${state.current.word}，再试一次。`, "danger");
+    setTimeout(() => recycleCurrentWord(), 720);
+  }
+}
+
+function advanceCurrentStage() {
+  if (!state.current) return;
+  state.current.stage += 1;
+  if (state.current.stage >= PRACTICE_STAGES.length) {
+    state.current.stage = PRACTICE_STAGES.length;
+    state.current.completedAt = Date.now();
+    state.current = state.queue.shift() ?? null;
+  }
+  state.locked = false;
+  renderCurrent();
+}
+
+function recycleCurrentWord() {
+  if (!state.current) return;
+  state.queue.push(state.current);
+  state.current = state.queue.shift() ?? null;
+  state.locked = false;
+  renderCurrent();
+  updateMistakeList();
+}
+
+function skipCurrentWord() {
+  if (!state.current || state.queue.length === 0) return;
+  state.queue.push(state.current);
+  state.current = state.queue.shift() ?? null;
+  renderCurrent();
+}
+
+function buildChoiceOptions(word) {
+  const options = [
+    { text: word.definition, correct: true }
+  ];
+  const used = new Set([word.definition]);
+  if (Array.isArray(word.confusions)) {
+    word.confusions.forEach((confuse) => {
+      if (!used.has(confuse.definition)) {
+        options.push({ text: confuse.definition, correct: false });
+        used.add(confuse.definition);
+      }
+    });
+  }
+  const pool = state.sessionWords
+    .filter((item) => item.word !== word.word)
+    .flatMap((item) => [item.definition, ...(item.confusions || []).map((conf) => conf.definition)])
+    .filter((definition) => !used.has(definition));
+  shuffleArray(pool);
+  while (options.length < 4 && pool.length) {
+    options.push({ text: pool.shift(), correct: false });
+  }
+  shuffleArray(options);
+  return options;
+}
+
+function highlightCorrectChoice() {
+  [...elements.choiceArea.querySelectorAll(".choice-button")].forEach((button) => {
+    if (button.dataset.correct === "true") {
+      button.classList.add("correct");
+    }
+  });
+}
+
+function pickDistractorDefinition(word) {
+  const pool = [];
+  if (Array.isArray(word.confusions)) {
+    word.confusions.forEach((item) => pool.push(item.definition));
+  }
+  state.sessionWords.forEach((item) => {
+    if (item.word !== word.word) {
+      pool.push(item.definition);
+      (item.confusions || []).forEach((conf) => pool.push(conf.definition));
+    }
+  });
+  const filtered = pool.filter((definition) => definition !== word.definition);
+  return filtered.length ? filtered[Math.floor(Math.random() * filtered.length)] : word.definition;
+}
+
+function showFeedback(text, type = "info") {
+  elements.feedback.textContent = text;
+  elements.feedback.style.color =
+    type === "success"
+      ? "#bbf7d0"
+      : type === "danger"
+      ? "#fecaca"
+      : type === "warning"
+      ? "#facc15"
+      : "var(--text-secondary)";
+}
+
+function showDefinitionHint() {
+  if (!state.current) return;
+  const confusions = (state.current.confusions || [])
+    .map((item) => `${item.word}: ${item.definition}`)
+    .join("；");
+  const hint = `释义：${state.current.definition}${confusions ? `\n形近词提示：${confusions}` : ""}`;
+  showFeedback(hint, "info");
+}
+
+function updateWordList() {
+  elements.wordList.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  state.sessionWords.forEach((item) => {
+    const li = document.createElement("li");
+    li.className = "word-item";
+    const name = document.createElement("span");
+    name.textContent = item.word;
+    const status = document.createElement("span");
+    status.className = "status";
+    if (item.stage >= PRACTICE_STAGES.length) {
+      status.textContent = "已完成";
+      status.classList.add("mastered");
+    } else if (state.current && item.id === state.current.id) {
+      status.textContent = `第 ${item.stage + 1} 关`;
+      status.classList.add("active");
+    } else if (item.mistakes > 0) {
+      status.textContent = `复习 ${item.mistakes}`;
+      status.classList.add("retry");
+    } else {
+      status.textContent = "待学习";
+      status.classList.add("pending");
+    }
+    li.appendChild(name);
+    li.appendChild(status);
+    fragment.appendChild(li);
+  });
+  elements.wordList.appendChild(fragment);
+  updateBatchHeader();
+}
+
+function recordMistake(word, stageId, detail) {
+  const key = word.word;
+  const entry = state.mistakes.get(key) || {
+    word: word.word,
+    definition: word.definition,
+    count: 0,
+    lastStage: stageId,
+    lastAnswer: detail
+  };
+  entry.count += 1;
+  entry.lastStage = stageId;
+  entry.lastAnswer = detail;
+  state.mistakes.set(key, entry);
+  word.mistakes += 1;
+  updateMistakeList();
+  updateWordList();
+}
+
+function updateMistakeList() {
+  elements.mistakeList.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  const items = Array.from(state.mistakes.values()).sort((a, b) => b.count - a.count);
+  if (!items.length) {
+    const empty = document.createElement("li");
+    empty.className = "word-item";
+    empty.textContent = "暂无错题，继续保持！";
+    fragment.appendChild(empty);
+  } else {
+    items.forEach((item) => {
+      const li = document.createElement("li");
+      li.className = "word-item";
+      const name = document.createElement("span");
+      name.textContent = item.word;
+      const detail = document.createElement("span");
+      detail.className = "status retry";
+      const stageName = PRACTICE_STAGES.find((stage) => stage.id === item.lastStage)?.pill || "错题";
+      detail.textContent = `${stageName} ×${item.count}`;
+      li.title = `正确释义：${item.definition}${item.lastAnswer ? `\n最近回答：${item.lastAnswer}` : ""}`;
+      li.appendChild(name);
+      li.appendChild(detail);
+      fragment.appendChild(li);
+    });
+  }
+  elements.mistakeList.appendChild(fragment);
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,495 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --panel: rgba(15, 23, 42, 0.75);
+  --surface: rgba(255, 255, 255, 0.08);
+  --border: rgba(255, 255, 255, 0.12);
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(248, 250, 252, 0.75);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --danger: #f87171;
+  --success: #4ade80;
+  --warning: #facc15;
+  --shadow: 0 40px 80px rgba(15, 23, 42, 0.45);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "SF Pro Display", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: linear-gradient(130deg, #0f172a, #1d4ed8 55%, #22d3ee 100%);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+  padding: 32px clamp(16px, 4vw, 48px);
+}
+
+.app-shell {
+  width: min(1180px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.top-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 24px;
+  align-items: center;
+  padding: 20px 24px;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(24px);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand-logo {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #38bdf8, #0ea5e9);
+  font-size: 28px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  letter-spacing: 0.04em;
+}
+
+.brand p {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.top-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+select {
+  appearance: none;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-primary);
+  font-size: 15px;
+}
+
+button {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ghost {
+  padding: 10px 16px;
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-primary);
+  transition: background 0.2s ease;
+}
+
+.ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.session-status {
+  text-align: right;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
+  gap: 24px;
+}
+
+.practice-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 540px;
+  padding: 24px;
+  border-radius: 32px;
+  background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.45), rgba(13, 148, 136, 0.45)),
+    rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(32px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stage-pill {
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.25);
+  color: #e0f2fe;
+  font-size: 14px;
+}
+
+.stage-tracker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stage-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+  position: relative;
+}
+
+.stage-dot.active::after,
+.stage-dot.completed::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+}
+
+.stage-dot.active {
+  background: var(--accent);
+}
+
+.stage-dot.active::after {
+  border: 2px solid rgba(56, 189, 248, 0.65);
+}
+
+.stage-dot.completed {
+  background: var(--success);
+}
+
+.stage-dot.completed::after {
+  border: 2px solid rgba(74, 222, 128, 0.65);
+}
+
+.card-progress {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.card-hero {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  gap: 16px;
+  margin: 32px 0 24px;
+  align-items: end;
+}
+
+.hero-word {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero-label {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+#word-text {
+  margin: 0;
+  font-size: clamp(42px, 6vw, 68px);
+  letter-spacing: 0.03em;
+}
+
+.hero-phonetic {
+  margin: 0;
+  font-size: 18px;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.hero-meta {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 20px;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+#stage-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.stage-description {
+  margin: 0;
+  font-size: 15px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.definition-inline {
+  display: inline-block;
+  margin-top: 6px;
+  color: #e0f2fe;
+}
+
+.card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.choice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.choice-button {
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--text-primary);
+  text-align: left;
+  line-height: 1.5;
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.choice-button:hover,
+.choice-button:focus-visible {
+  transform: translateY(-4px);
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.choice-button.correct {
+  border-color: rgba(74, 222, 128, 0.75);
+  background: rgba(74, 222, 128, 0.2);
+}
+
+.choice-button.wrong {
+  border-color: rgba(248, 113, 113, 0.75);
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.tf-actions {
+  display: flex;
+  gap: 16px;
+}
+
+.action {
+  padding: 14px 26px;
+  border-radius: 999px;
+  color: #0f172a;
+  font-weight: 600;
+  transition: transform 0.18s ease, filter 0.18s ease;
+}
+
+.action.primary {
+  background: linear-gradient(135deg, #bae6fd, #38bdf8);
+}
+
+.action.danger {
+  background: linear-gradient(135deg, #fecaca, #f87171);
+}
+
+.action.success {
+  background: linear-gradient(135deg, #bbf7d0, #4ade80);
+}
+
+.action:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
+}
+
+.spelling-box {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.spelling-box label {
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.spelling-input {
+  display: flex;
+  gap: 12px;
+}
+
+#spell-input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.feedback {
+  min-height: 28px;
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.summary {
+  padding: 20px 22px;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+}
+
+.summary h2 {
+  margin: 0 0 16px;
+  font-size: 18px;
+}
+
+.word-list,
+.mistake-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.word-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.word-item .status {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status.pending {
+  background: rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.status.active {
+  background: rgba(56, 189, 248, 0.25);
+  color: #bae6fd;
+}
+
+.status.mastered {
+  background: rgba(74, 222, 128, 0.25);
+  color: #bbf7d0;
+}
+
+.status.retry {
+  background: rgba(248, 113, 113, 0.25);
+  color: #fecaca;
+}
+
+.summary.info ol {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 1080px) {
+  body {
+    padding: 24px;
+  }
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+  .side-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .summary {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+  .top-controls {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+  .card-hero {
+    grid-template-columns: 1fr;
+  }
+  #word-text {
+    font-size: clamp(36px, 12vw, 56px);
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the study layout with a Baicizhan-inspired practice card, batch controls, and progress sidebars
- implement 10-word session batches that cycle each word through confusion choice, true/false judgement, and spelling recall with automatic requeueing on mistakes
- track mistake history and live word statuses to focus review on weak items while celebrating completions

## Testing
- manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68d75ed88bf0832bb5db193edff8c474