### PR TITLE
Add multi-stage drills and Excel exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>记忆冲刺｜背单词训练营</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="top-bar" aria-label="批次与词库设置">
+      <div class="brand">
+        <span class="brand-logo" aria-hidden="true">⚡</span>
+        <div>
+          <h1>记忆冲刺</h1>
+          <p>参考百词斩节奏，10 词一组多题型巩固</p>
+        </div>
+      </div>
+      <div class="top-controls">
+        <label class="field">
+          <span>选择词库</span>
+          <select id="word-pack" aria-label="选择词库"></select>
+        </label>
+        <button id="prev-batch" class="ghost" type="button">上一组</button>
+        <button id="next-batch" class="ghost" type="button">下一组</button>
+      </div>
+      <div class="export-controls">
+        <button id="export-today" class="ghost" type="button">导出今日学习 Excel</button>
+        <button id="export-library" class="ghost" type="button">下载词库 Excel</button>
+      </div>
+      <div class="session-status">
+        <p><strong id="batch-title">第 1 组</strong></p>
+        <p id="batch-progress">0 / 0 完成</p>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <section class="practice-zone" aria-live="polite">
+        <article class="practice-card" id="practice-card">
+          <header class="card-header">
+            <span id="stage-pill" class="stage-pill">选择释义</span>
+            <div class="stage-tracker" id="stage-tracker" aria-label="本词训练阶段进度"></div>
+            <div class="card-progress">
+              <span id="word-counter">0 / 0</span>
+            </div>
+          </header>
+          <div class="card-hero">
+            <div class="hero-word">
+              <p class="hero-label">当前单词</p>
+              <h2 id="word-text">请选择词库</h2>
+              <p id="phonetic-text" class="hero-phonetic"></p>
+            </div>
+            <div class="hero-meta">
+              <p id="stage-title">请选择词库开始训练</p>
+              <p id="stage-description" class="stage-description"></p>
+            </div>
+          </div>
+          <div class="card-body">
+            <div id="shape-area" class="choice-grid" role="group" aria-label="形近词辨析" hidden></div>
+            <div id="meaning-area" class="choice-grid" role="group" aria-label="释义选择" hidden></div>
+            <div id="spelling-choice-area" class="choice-grid" role="group" aria-label="拼写选择" hidden></div>
+            <div id="spelling-area" class="spelling-box" hidden>
+              <label for="spell-input">请输入单词拼写</label>
+              <div class="spelling-input">
+                <input id="spell-input" type="text" autocomplete="off" spellcheck="false" />
+                <button id="spell-submit" type="button" class="action primary">提交</button>
+              </div>
+            </div>
+            <div id="reveal-area" class="reveal-panel" hidden>
+              <h3>词义速览</h3>
+              <ul id="reveal-list"></ul>
+            </div>
+            <p id="feedback" class="feedback" role="status"></p>
+          </div>
+          <footer class="card-footer">
+            <button id="replay-word" class="ghost" type="button">再看一次释义</button>
+            <button id="skip-word" class="ghost" type="button">换个单词</button>
+          </footer>
+        </article>
+      </section>
+
+      <aside class="side-panel" aria-label="批次进度与待巩固">
+        <section class="summary">
+          <h2>本组词汇</h2>
+          <ul id="word-list" class="word-list"></ul>
+        </section>
+        <section class="summary">
+          <h2>错题回顾</h2>
+          <ul id="mistake-list" class="mistake-list"></ul>
+        </section>
+        <section class="summary info">
+          <h2>学习节奏</h2>
+          <ol>
+            <li>形近辨析：在多个释义里选出正确项。</li>
+            <li>释义判断：快速判断对错，强化语义映射。</li>
+            <li>拼写回忆：闭眼默写，完成从识记到输出。</li>
+          </ol>
+        </section>
+      </aside>
+    </main>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js" integrity="sha384-x8YiXfSsbJgDnJVq+5p46nzbNMlgqf/rWqRMf2FB8s8pEMyprUIE3by9LmFvqR0P" crossorigin="anonymous"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1057 @@
+const WORD_PACKS = {
+  "考研词汇": [
+    {
+      word: "ameliorate",
+      definition: "v. 改善；使好转",
+      phonetic: "əˈmiːliəreɪt",
+      example: "A well-structured review plan can ameliorate exam anxiety.",
+      confusions: [
+        { word: "deteriorate", definition: "v. 恶化；退化" },
+        { word: "alleviate", definition: "v. 缓解；减轻" },
+        { word: "mitigate", definition: "v. 缓和；减轻" }
+      ]
+    },
+    {
+      word: "meticulous",
+      definition: "adj. 一丝不苟的；严谨的",
+      phonetic: "məˈtɪkjələs",
+      example: "She kept meticulous notes of every practice test.",
+      confusions: [
+        { word: "fastidious", definition: "adj. 挑剔的；极其注意细节的" },
+        { word: "scrupulous", definition: "adj. 严谨认真的；一丝不苟的" },
+        { word: "methodical", definition: "adj. 有条理的；井井有条的" }
+      ]
+    },
+    {
+      word: "exacerbate",
+      definition: "v. 使恶化；使加剧",
+      phonetic: "ɪɡˈzæsəbeɪt",
+      example: "Skipping reviews will exacerbate the forgetting problem.",
+      confusions: [
+        { word: "exasperate", definition: "v. 激怒；使恼怒" },
+        { word: "aggravate", definition: "v. 使加重；加剧" },
+        { word: "excavate", definition: "v. 挖掘；开凿" }
+      ]
+    },
+    {
+      word: "pragmatic",
+      definition: "adj. 务实的；讲求实际的",
+      phonetic: "præɡˈmætɪk",
+      example: "A pragmatic learner blends flashcards with writing practice.",
+      confusions: [
+        { word: "dogmatic", definition: "adj. 教条的；武断的" },
+        { word: "programmatic", definition: "adj. 程序化的；规划性的" },
+        { word: "practicable", definition: "adj. 可行的；能实行的" }
+      ]
+    },
+    {
+      word: "delineate",
+      definition: "v. 描述；勾画轮廓",
+      phonetic: "dɪˈlɪnieɪt",
+      example: "The teacher delineated the key grammar points in detail.",
+      confusions: [
+        { word: "eliminate", definition: "v. 消除；淘汰" },
+        { word: "deliberate", definition: "v. 深思熟虑；adj. 故意的" },
+        { word: "alienate", definition: "v. 疏远；离间" }
+      ]
+    },
+    {
+      word: "ubiquitous",
+      definition: "adj. 无处不在的；普遍存在的",
+      phonetic: "juːˈbɪkwɪtəs",
+      example: "Mobile apps make ubiquitous learning possible.",
+      confusions: [
+        { word: "unique", definition: "adj. 独一无二的" },
+        { word: "oblivious", definition: "adj. 遗忘的；未察觉的" },
+        { word: "ambiguous", definition: "adj. 模棱两可的；含糊的" }
+      ]
+    },
+    {
+      word: "pertinent",
+      definition: "adj. 相关的；中肯的",
+      phonetic: "ˈpɜːrtɪnənt",
+      example: "Only pertinent examples are kept in the final notes.",
+      confusions: [
+        { word: "impertinent", definition: "adj. 无礼的；不相关的" },
+        { word: "penitent", definition: "adj. 忏悔的；悔过的" },
+        { word: "perturb", definition: "v. 使不安；扰乱" }
+      ]
+    },
+    {
+      word: "alleviate",
+      definition: "v. 缓解；减轻",
+      phonetic: "əˈliːvieɪt",
+      example: "Regular breaks can alleviate fatigue during revision.",
+      confusions: [
+        { word: "aggravate", definition: "v. 加重；恶化" },
+        { word: "elevate", definition: "v. 提升；举起" },
+        { word: "levitate", definition: "v. 升空；悬浮" }
+      ]
+    },
+    {
+      word: "galvanize",
+      definition: "v. 激励；通电镀锌",
+      phonetic: "ˈɡælvənaɪz",
+      example: "The looming exam date galvanized her to study harder.",
+      confusions: [
+        { word: "paralyze", definition: "v. 使瘫痪；使麻痹" },
+        { word: "vulcanize", definition: "v. 硫化；硫化处理" },
+        { word: "aggrandize", definition: "v. 扩张；夸大" }
+      ]
+    },
+    {
+      word: "consolidate",
+      definition: "v. 巩固；合并",
+      phonetic: "kənˈsɑːlɪdeɪt",
+      example: "Daily review consolidates long-term memory.",
+      confusions: [
+        { word: "liquidate", definition: "v. 清算；变现" },
+        { word: "insulate", definition: "v. 使隔离；绝缘" },
+        { word: "consulate", definition: "n. 领事馆" }
+      ]
+    }
+  ],
+  "GRE词汇": [
+    {
+      word: "abrogate",
+      definition: "v. 废除；撤销",
+      phonetic: "ˈæbrəɡeɪt",
+      example: "The committee voted to abrogate the outdated rule.",
+      confusions: [
+        { word: "arrogate", definition: "v. 冒称拥有；霸占" },
+        { word: "abdicate", definition: "v. 退位；放弃权力" },
+        { word: "aggregate", definition: "v. 聚合；总计" }
+      ]
+    },
+    {
+      word: "intransigent",
+      definition: "adj. 不妥协的；固执的",
+      phonetic: "ɪnˈtrænsɪdʒənt",
+      example: "The negotiator faced an intransigent opponent.",
+      confusions: [
+        { word: "insurgent", definition: "n. 叛乱者；起义者" },
+        { word: "stringent", definition: "adj. 严格的；紧缩的" },
+        { word: "transient", definition: "adj. 短暂的；转瞬即逝的" }
+      ]
+    },
+    {
+      word: "proscribe",
+      definition: "v. 禁止；取缔",
+      phonetic: "proʊˈskraɪb",
+      example: "The policy proscribed the use of informal sources.",
+      confusions: [
+        { word: "prescribe", definition: "v. 开药方；规定" },
+        { word: "subscribe", definition: "v. 订阅；赞同" },
+        { word: "describe", definition: "v. 描述；形容" }
+      ]
+    },
+    {
+      word: "obviate",
+      definition: "v. 排除；使无必要",
+      phonetic: "ˈɑːbvieɪt",
+      example: "Consistent practice obviates last-minute cramming.",
+      confusions: [
+        { word: "deviate", definition: "v. 偏离；背离" },
+        { word: "obligate", definition: "v. 强迫；使负义务" },
+        { word: "oblate", definition: "adj. 扁圆的；球形扁平的" }
+      ]
+    },
+    {
+      word: "ephemeral",
+      definition: "adj. 短暂的；转瞬即逝的",
+      phonetic: "ɪˈfemərəl",
+      example: "Ephemeral memory fades quickly without review.",
+      confusions: [
+        { word: "eternal", definition: "adj. 永恒的" },
+        { word: "ethereal", definition: "adj. 飘渺的；超凡的" },
+        { word: "empirical", definition: "adj. 经验主义的；以经验为依据的" }
+      ]
+    },
+    {
+      word: "vociferous",
+      definition: "adj. 喧哗的；大声疾呼的",
+      phonetic: "voʊˈsɪfərəs",
+      example: "Vociferous critics demanded a better syllabus.",
+      confusions: [
+        { word: "voracious", definition: "adj. 贪吃的；求知欲强的" },
+        { word: "ferocious", definition: "adj. 凶猛的；残暴的" },
+        { word: "loquacious", definition: "adj. 健谈的；话多的" }
+      ]
+    },
+    {
+      word: "recalcitrant",
+      definition: "adj. 桀骜不驯的；顽抗的",
+      phonetic: "rɪˈkælsɪtrənt",
+      example: "A recalcitrant habit resists sudden change.",
+      confusions: [
+        { word: "reticent", definition: "adj. 寡言少语的；不愿透露的" },
+        { word: "recalibrate", definition: "v. 重新校准；重新调整" },
+        { word: "recreant", definition: "adj. 懦弱的；背信弃义的" }
+      ]
+    },
+    {
+      word: "pellucid",
+      definition: "adj. 清澈的；清晰易懂的",
+      phonetic: "pəˈluːsɪd",
+      example: "Her pellucid explanation clarified the theory.",
+      confusions: [
+        { word: "recondite", definition: "adj. 深奥的；难懂的" },
+        { word: "translucent", definition: "adj. 半透明的" },
+        { word: "pelagic", definition: "adj. 海洋的；远洋的" }
+      ]
+    },
+    {
+      word: "sedulous",
+      definition: "adj. 勤奋的；刻苦的",
+      phonetic: "ˈsedʒələs",
+      example: "Sedulous effort eventually pays off in vocabulary building.",
+      confusions: [
+        { word: "seditious", definition: "adj. 煽动性的；闹革命的" },
+        { word: "sedentary", definition: "adj. 久坐不动的" },
+        { word: "seductive", definition: "adj. 诱惑的；迷人的" }
+      ]
+    },
+    {
+      word: "castigate",
+      definition: "v. 严厉批评；惩罚",
+      phonetic: "ˈkæstɪɡeɪt",
+      example: "The professor castigated plagiarism harshly.",
+      confusions: [
+        { word: "extol", definition: "v. 赞美；颂扬" },
+        { word: "castrate", definition: "v. 阉割；阉除" },
+        { word: "investigate", definition: "v. 调查；研究" }
+      ]
+    }
+  ]
+};
+
+const PRACTICE_STAGES = [
+  {
+    id: "shape",
+    pill: "形近辨析",
+    title: "形近词快速辨析",
+    description: "先在 4 个形近词里锁定本词，不提前显示中文释义，考验英文敏感度。"
+  },
+  {
+    id: "meaning",
+    pill: "释义选择",
+    title: "释义精准匹配",
+    description: "结合上下文，在 4 个释义中选出最贴合的中文含义。"
+  },
+  {
+    id: "spellingChoice",
+    pill: "拼写选择",
+    title: "拼写形态辨别",
+    description: "从 4 个拼写形态中挑出正确写法，巩固字母顺序。"
+  },
+  {
+    id: "spelling",
+    pill: "拼写回忆",
+    title: "完整拼写",
+    description: "根据释义默写单词，完成从识记到输出的闭环。"
+  }
+];
+
+const BATCH_SIZE = 10;
+
+const state = {
+  packName: "",
+  packWords: [],
+  batchIndex: 0,
+  batchCount: 0,
+  sessionWords: [],
+  queue: [],
+  current: null,
+  locked: false,
+  prompt: null,
+  mistakes: new Map(),
+  dailyRecords: []
+};
+
+const elements = {};
+
+document.addEventListener("DOMContentLoaded", () => {
+  cacheElements();
+  bindEvents();
+  initPackOptions();
+});
+
+function cacheElements() {
+  elements.packSelect = document.getElementById("word-pack");
+  elements.prevBatch = document.getElementById("prev-batch");
+  elements.nextBatch = document.getElementById("next-batch");
+  elements.batchTitle = document.getElementById("batch-title");
+  elements.batchProgress = document.getElementById("batch-progress");
+  elements.wordCounter = document.getElementById("word-counter");
+  elements.stagePill = document.getElementById("stage-pill");
+  elements.stageTracker = document.getElementById("stage-tracker");
+  elements.wordText = document.getElementById("word-text");
+  elements.phoneticText = document.getElementById("phonetic-text");
+  elements.stageTitle = document.getElementById("stage-title");
+  elements.stageDescription = document.getElementById("stage-description");
+  elements.shapeArea = document.getElementById("shape-area");
+  elements.meaningArea = document.getElementById("meaning-area");
+  elements.spellingChoiceArea = document.getElementById("spelling-choice-area");
+  elements.spellingArea = document.getElementById("spelling-area");
+  elements.spellInput = document.getElementById("spell-input");
+  elements.spellSubmit = document.getElementById("spell-submit");
+  elements.feedback = document.getElementById("feedback");
+  elements.revealArea = document.getElementById("reveal-area");
+  elements.revealList = document.getElementById("reveal-list");
+  elements.replay = document.getElementById("replay-word");
+  elements.skip = document.getElementById("skip-word");
+  elements.wordList = document.getElementById("word-list");
+  elements.mistakeList = document.getElementById("mistake-list");
+  elements.exportToday = document.getElementById("export-today");
+  elements.exportLibrary = document.getElementById("export-library");
+}
+
+function bindEvents() {
+  elements.packSelect.addEventListener("change", () => {
+    const name = elements.packSelect.value;
+    preparePack(name);
+  });
+
+  elements.prevBatch.addEventListener("click", () => {
+    if (state.batchIndex > 0) {
+      startBatch(state.batchIndex - 1);
+    }
+  });
+
+  elements.nextBatch.addEventListener("click", () => {
+    if (state.batchIndex < state.batchCount - 1) {
+      startBatch(state.batchIndex + 1);
+    }
+  });
+
+  elements.spellSubmit.addEventListener("click", () => handleSpellingSubmit());
+  elements.spellInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSpellingSubmit();
+    }
+  });
+
+  elements.replay.addEventListener("click", showDefinitionHint);
+  elements.skip.addEventListener("click", skipCurrentWord);
+  elements.exportToday.addEventListener("click", exportTodayExcel);
+  elements.exportLibrary.addEventListener("click", exportLibraryExcel);
+}
+
+function initPackOptions() {
+  const fragment = document.createDocumentFragment();
+  Object.keys(WORD_PACKS).forEach((name) => {
+    const option = document.createElement("option");
+    option.value = name;
+    option.textContent = name;
+    fragment.appendChild(option);
+  });
+  elements.packSelect.appendChild(fragment);
+  const firstPack = Object.keys(WORD_PACKS)[0];
+  elements.packSelect.value = firstPack;
+  preparePack(firstPack);
+}
+
+function preparePack(name) {
+  state.packName = name;
+  const rawWords = WORD_PACKS[name] ?? [];
+  state.packWords = rawWords.map((item, index) => ({
+    ...item,
+    id: `${name}-${index}`
+  }));
+  state.batchCount = Math.max(1, Math.ceil(state.packWords.length / BATCH_SIZE));
+  startBatch(0);
+}
+
+function startBatch(batchIndex) {
+  state.batchIndex = batchIndex;
+  state.mistakes.clear();
+  const start = batchIndex * BATCH_SIZE;
+  const slice = state.packWords.slice(start, start + BATCH_SIZE);
+  state.sessionWords = slice.map((item, index) => ({
+    id: `${item.id}-${batchIndex}-${index}`,
+    word: item.word,
+    definition: item.definition,
+    phonetic: item.phonetic ?? "",
+    example: item.example ?? "",
+    confusions: Array.isArray(item.confusions) ? [...item.confusions] : [],
+    stage: 0,
+    mistakes: 0
+  }));
+  state.queue = state.sessionWords.slice();
+  shuffleArray(state.queue);
+  state.current = state.queue.shift() ?? null;
+  state.locked = false;
+  state.prompt = null;
+  updateBatchHeader();
+  renderCurrent();
+  updateWordList();
+  updateMistakeList();
+  updateBatchButtons();
+}
+
+function updateBatchButtons() {
+  elements.prevBatch.disabled = state.batchIndex <= 0;
+  elements.nextBatch.disabled = state.batchIndex >= state.batchCount - 1;
+}
+
+function updateBatchHeader() {
+  const title = state.batchCount > 1 ? `第 ${state.batchIndex + 1} 组` : "本组词汇";
+  elements.batchTitle.textContent = title;
+  const finished = state.sessionWords.filter((word) => word.stage >= PRACTICE_STAGES.length).length;
+  const total = state.sessionWords.length;
+  elements.batchProgress.textContent = `${finished} / ${total} 完成`;
+}
+
+function renderCurrent() {
+  const { current } = state;
+  const total = state.sessionWords.length;
+  const finished = state.sessionWords.filter((word) => word.stage >= PRACTICE_STAGES.length).length;
+
+  if (!current) {
+    hideAllStageAreas();
+    elements.stagePill.textContent = "全部完成";
+    elements.stageTracker.innerHTML = "";
+    elements.wordText.textContent = total ? "本组已通关" : "暂无单词";
+    elements.phoneticText.textContent = "";
+    elements.stageTitle.textContent = total ? "干得漂亮！" : "请先添加词库";
+    elements.stageDescription.textContent = total
+      ? "可以切换下一组或重新开始巩固错词。"
+      : "选择包含单词的词库开始训练。";
+    elements.feedback.textContent = total
+      ? "错题已加入右侧列表，随时复盘。"
+      : "";
+    elements.wordCounter.textContent = `${finished} / ${total}`;
+    elements.skip.disabled = true;
+    return;
+  }
+
+  const stage = PRACTICE_STAGES[current.stage];
+  elements.stagePill.textContent = stage.pill;
+  elements.stageTitle.textContent = stage.title;
+  elements.stageDescription.textContent = stage.description;
+  elements.wordText.textContent = current.word;
+  elements.phoneticText.textContent = current.phonetic || "";
+  elements.feedback.textContent = "";
+  elements.wordCounter.textContent = `第 ${Math.min(finished + 1, total)} / ${total} 词`;
+
+  renderStageTracker(current.stage);
+
+  state.prompt = null;
+  hideAllStageAreas();
+
+  switch (stage.id) {
+    case "shape":
+      renderShapeStage(current);
+      break;
+    case "meaning":
+      renderMeaningStage(current);
+      break;
+    case "spellingChoice":
+      renderSpellingChoiceStage(current);
+      break;
+    case "spelling":
+      renderSpellingStage(current);
+      break;
+    default:
+      break;
+  }
+
+  state.locked = false;
+  updateBatchHeader();
+  updateWordList();
+  elements.skip.disabled = state.queue.length === 0;
+}
+
+function renderStageTracker(activeIndex) {
+  elements.stageTracker.innerHTML = "";
+  PRACTICE_STAGES.forEach((stage, index) => {
+    const dot = document.createElement("span");
+    dot.className = "stage-dot";
+    if (index < activeIndex) {
+      dot.classList.add("completed");
+    } else if (index === activeIndex) {
+      dot.classList.add("active");
+    }
+    elements.stageTracker.appendChild(dot);
+  });
+}
+
+function hideAllStageAreas() {
+  elements.shapeArea.hidden = true;
+  elements.meaningArea.hidden = true;
+  elements.spellingChoiceArea.hidden = true;
+  elements.spellingArea.hidden = true;
+  elements.revealArea.hidden = true;
+  elements.shapeArea.innerHTML = "";
+  elements.meaningArea.innerHTML = "";
+  elements.spellingChoiceArea.innerHTML = "";
+  elements.revealList.innerHTML = "";
+}
+
+function renderShapeStage(word) {
+  elements.shapeArea.hidden = false;
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}`;
+  const options = buildShapeOptions(word);
+  const fragment = document.createDocumentFragment();
+  options.forEach((option) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "choice-button";
+    button.textContent = option.word;
+    button.dataset.correct = option.correct ? "true" : "false";
+    button.addEventListener("click", () => {
+      if (state.locked) return;
+      state.locked = true;
+      highlightCorrectButtons(elements.shapeArea);
+      showRevealPanel(options);
+      if (option.correct) {
+        button.classList.add("correct");
+        showFeedback("辨析准确！来看释义。", "success");
+        scheduleStageTransition(true);
+      } else {
+        button.classList.add("wrong");
+        recordMistake(word, "shape", option.word);
+        showFeedback("再对照一下形近词，稍后继续巩固。", "danger");
+        scheduleStageTransition(false);
+      }
+    });
+    fragment.appendChild(button);
+  });
+  elements.shapeArea.appendChild(fragment);
+}
+
+function renderMeaningStage(word) {
+  elements.meaningArea.hidden = false;
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}`;
+  const options = buildMeaningOptions(word);
+  const fragment = document.createDocumentFragment();
+  options.forEach((option) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "choice-button";
+    button.textContent = option.text;
+    button.dataset.correct = option.correct ? "true" : "false";
+    button.addEventListener("click", () => {
+      if (state.locked) return;
+      state.locked = true;
+      highlightCorrectButtons(elements.meaningArea);
+      if (option.correct) {
+        button.classList.add("correct");
+        showFeedback("释义匹配成功，继续加油！", "success");
+        scheduleStageTransition(true);
+      } else {
+        button.classList.add("wrong");
+        recordMistake(word, "meaning", option.text);
+        showFeedback("释义没对上，我们再练一次。", "danger");
+        scheduleStageTransition(false);
+      }
+    });
+    fragment.appendChild(button);
+  });
+  elements.meaningArea.appendChild(fragment);
+}
+
+function renderSpellingChoiceStage(word) {
+  elements.spellingChoiceArea.hidden = false;
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}`;
+  const options = buildSpellingChoiceOptions(word);
+  const fragment = document.createDocumentFragment();
+  options.forEach((option) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "choice-button";
+    button.textContent = option.text;
+    button.dataset.correct = option.correct ? "true" : "false";
+    button.addEventListener("click", () => {
+      if (state.locked) return;
+      state.locked = true;
+      highlightCorrectButtons(elements.spellingChoiceArea);
+      if (option.correct) {
+        button.classList.add("correct");
+        showFeedback("拼写形态辨识正确！", "success");
+        scheduleStageTransition(true);
+      } else {
+        button.classList.add("wrong");
+        recordMistake(word, "spellingChoice", option.text);
+        showFeedback("正确拼写不是这个，稍后我们再来。", "danger");
+        scheduleStageTransition(false);
+      }
+    });
+    fragment.appendChild(button);
+  });
+  elements.spellingChoiceArea.appendChild(fragment);
+}
+
+function scheduleStageTransition(correct) {
+  setTimeout(() => {
+    if (correct) {
+      advanceCurrentStage();
+    } else {
+      recycleCurrentWord();
+    }
+  }, 720);
+}
+
+function renderSpellingStage(word) {
+  elements.spellingArea.hidden = false;
+  elements.spellInput.value = "";
+  try {
+    elements.spellInput.focus({ preventScroll: true });
+  } catch (error) {
+    elements.spellInput.focus();
+  }
+  state.prompt = {
+    stage: "spelling",
+    answer: word.word.toLowerCase()
+  };
+  elements.stageDescription.innerHTML = `${PRACTICE_STAGES[word.stage].description}<br><span class="definition-inline">释义：${word.definition}</span>`;
+  showRevealPanel([
+    { word: word.word, definition: word.definition, correct: true },
+    ...collectWordDistractors(word, 2)
+  ]);
+}
+
+function handleSpellingSubmit() {
+  if (state.locked || !state.current || !state.prompt || state.prompt.stage !== "spelling") {
+    return;
+  }
+  const input = elements.spellInput.value.trim();
+  if (!input) {
+    showFeedback("先尝试拼写一下吧～", "warning");
+    return;
+  }
+  state.locked = true;
+  const answer = state.prompt.answer;
+  if (input.toLowerCase() === answer) {
+    showFeedback("太棒了！本词已完成所有练习。", "success");
+    setTimeout(() => advanceCurrentStage(), 640);
+  } else {
+    recordMistake(state.current, "spelling", input);
+    showFeedback(`正确拼写是 ${state.current.word}，再试一次。`, "danger");
+    setTimeout(() => recycleCurrentWord(), 720);
+  }
+}
+
+function advanceCurrentStage() {
+  if (!state.current) return;
+  state.current.stage += 1;
+  if (state.current.stage >= PRACTICE_STAGES.length) {
+    state.current.stage = PRACTICE_STAGES.length;
+    state.current.completedAt = Date.now();
+    recordCompletion(state.current);
+    state.current = state.queue.shift() ?? null;
+  }
+  state.locked = false;
+  renderCurrent();
+}
+
+function recycleCurrentWord() {
+  if (!state.current) return;
+  state.queue.push(state.current);
+  state.current = state.queue.shift() ?? null;
+  state.locked = false;
+  renderCurrent();
+  updateMistakeList();
+}
+
+function skipCurrentWord() {
+  if (!state.current || state.queue.length === 0) return;
+  state.queue.push(state.current);
+  state.current = state.queue.shift() ?? null;
+  renderCurrent();
+}
+
+function buildShapeOptions(word) {
+  const distractors = collectWordDistractors(word, 3);
+  const options = [
+    { word: word.word, definition: word.definition, correct: true },
+    ...distractors.map((item) => ({
+      word: item.word,
+      definition: item.definition || "（暂无释义）",
+      correct: false
+    }))
+  ];
+  shuffleArray(options);
+  return options;
+}
+
+function buildMeaningOptions(word) {
+  const distractors = collectMeaningDistractors(word, 3);
+  const options = [
+    { text: word.definition, correct: true },
+    ...distractors.map((definition) => ({ text: definition, correct: false }))
+  ];
+  shuffleArray(options);
+  return options;
+}
+
+function buildSpellingChoiceOptions(word) {
+  const base = (word.word || "").trim().toLowerCase();
+  const variants = new Set([base]);
+  let guard = 0;
+  while (variants.size < 4 && guard < 48) {
+    const candidate = createWordVariant(base);
+    if (candidate && !variants.has(candidate)) {
+      variants.add(candidate);
+    }
+    guard += 1;
+  }
+  const array = Array.from(variants).map((variant) => ({
+    text: variant,
+    correct: variant === base
+  }));
+  shuffleArray(array);
+  return array;
+}
+
+function createWordVariant(base) {
+  const letters = base.split("");
+  if (letters.length <= 2) {
+    return `${base}${base.slice(-1)}`;
+  }
+  const operations = ["swap", "replace", "drop", "insert"];
+  const op = operations[Math.floor(Math.random() * operations.length)];
+  switch (op) {
+    case "swap": {
+      const index = Math.floor(Math.random() * (letters.length - 1));
+      const clone = [...letters];
+      [clone[index], clone[index + 1]] = [clone[index + 1], clone[index]];
+      const result = clone.join("");
+      if (result !== base) return result;
+      break;
+    }
+    case "replace": {
+      const index = Math.floor(Math.random() * letters.length);
+      const clone = [...letters];
+      const replacement = getRandomLetter(clone[index]);
+      clone[index] = replacement;
+      const result = clone.join("");
+      if (result !== base) return result;
+      break;
+    }
+    case "drop": {
+      if (letters.length <= 3) break;
+      const index = Math.floor(Math.random() * letters.length);
+      const clone = letters.filter((_, idx) => idx !== index);
+      const result = clone.join("");
+      if (result !== base && result.length) return result;
+      break;
+    }
+    case "insert": {
+      const index = Math.floor(Math.random() * (letters.length + 1));
+      const clone = [...letters];
+      clone.splice(index, 0, getRandomLetter());
+      const result = clone.join("");
+      if (result !== base) return result;
+      break;
+    }
+    default:
+      break;
+  }
+  return `${base}${getRandomLetter()}`;
+}
+
+function getRandomLetter(exclude) {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz";
+  let letter = alphabet[Math.floor(Math.random() * alphabet.length)];
+  if (exclude) {
+    let guard = 0;
+    while (letter === exclude && guard < 26) {
+      letter = alphabet[Math.floor(Math.random() * alphabet.length)];
+      guard += 1;
+    }
+  }
+  return letter;
+}
+
+function highlightCorrectButtons(container) {
+  container.querySelectorAll(".choice-button").forEach((button) => {
+    if (button.dataset.correct === "true") {
+      button.classList.add("correct");
+    }
+  });
+}
+
+function showRevealPanel(entries) {
+  if (!entries || !entries.length) {
+    elements.revealArea.hidden = true;
+    elements.revealList.innerHTML = "";
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  entries.forEach((entry) => {
+    const li = document.createElement("li");
+    if (entry.correct) {
+      li.classList.add("correct");
+    }
+    const wordSpan = document.createElement("strong");
+    wordSpan.textContent = entry.word;
+    const definitionSpan = document.createElement("span");
+    definitionSpan.textContent = entry.definition || "（暂无释义）";
+    li.appendChild(wordSpan);
+    li.appendChild(definitionSpan);
+    fragment.appendChild(li);
+  });
+  elements.revealList.innerHTML = "";
+  elements.revealList.appendChild(fragment);
+  elements.revealArea.hidden = false;
+}
+
+function collectWordDistractors(word, desired) {
+  const results = [];
+  const used = new Set([word.word?.toLowerCase()]);
+  if (Array.isArray(word.confusions)) {
+    const pool = [...word.confusions];
+    shuffleArray(pool);
+    pool.forEach((item) => {
+      const key = item.word?.toLowerCase();
+      if (key && !used.has(key) && results.length < desired) {
+        results.push({ word: item.word, definition: item.definition });
+        used.add(key);
+      }
+    });
+  }
+  if (results.length < desired) {
+    const poolSource = Array.isArray(state.packWords) ? state.packWords : [];
+    const pool = poolSource
+      .filter((item) => item.word.toLowerCase() !== word.word.toLowerCase())
+      .map((item) => ({ word: item.word, definition: item.definition }));
+    shuffleArray(pool);
+    pool.forEach((item) => {
+      const key = item.word?.toLowerCase();
+      if (key && !used.has(key) && results.length < desired) {
+        results.push({ word: item.word, definition: item.definition });
+        used.add(key);
+      }
+    });
+  }
+  return results.slice(0, desired);
+}
+
+function collectMeaningDistractors(word, desired) {
+  const results = [];
+  const used = new Set([word.definition]);
+  if (Array.isArray(word.confusions)) {
+    const pool = [...word.confusions];
+    shuffleArray(pool);
+    pool.forEach((item) => {
+      if (item.definition && !used.has(item.definition) && results.length < desired) {
+        results.push(item.definition);
+        used.add(item.definition);
+      }
+    });
+  }
+  if (results.length < desired) {
+    const poolSource = Array.isArray(state.packWords) ? state.packWords : [];
+    const pool = poolSource
+      .filter((item) => item.word !== word.word)
+      .flatMap((item) => [item.definition, ...(item.confusions || []).map((conf) => conf.definition)])
+      .filter(Boolean);
+    shuffleArray(pool);
+    pool.forEach((definition) => {
+      if (!used.has(definition) && results.length < desired) {
+        results.push(definition);
+        used.add(definition);
+      }
+    });
+  }
+  return results.slice(0, desired);
+}
+
+function showFeedback(text, type = "info") {
+  elements.feedback.textContent = text;
+  elements.feedback.style.color =
+    type === "success"
+      ? "#bbf7d0"
+      : type === "danger"
+      ? "#fecaca"
+      : type === "warning"
+      ? "#facc15"
+      : "var(--text-secondary)";
+}
+
+function showDefinitionHint() {
+  if (!state.current) return;
+  const entries = [
+    { word: state.current.word, definition: state.current.definition, correct: true },
+    ...collectWordDistractors(state.current, 3)
+  ];
+  showRevealPanel(entries);
+  showFeedback("已展示当前单词与形近词释义对照。", "info");
+}
+
+function updateWordList() {
+  elements.wordList.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  state.sessionWords.forEach((item) => {
+    const li = document.createElement("li");
+    li.className = "word-item";
+    const name = document.createElement("span");
+    name.textContent = item.word;
+    const status = document.createElement("span");
+    status.className = "status";
+    if (item.stage >= PRACTICE_STAGES.length) {
+      status.textContent = "已完成";
+      status.classList.add("mastered");
+    } else if (state.current && item.id === state.current.id) {
+      status.textContent = `第 ${item.stage + 1} 关`;
+      status.classList.add("active");
+    } else if (item.mistakes > 0) {
+      status.textContent = `复习 ${item.mistakes}`;
+      status.classList.add("retry");
+    } else {
+      status.textContent = "待学习";
+      status.classList.add("pending");
+    }
+    li.appendChild(name);
+    li.appendChild(status);
+    fragment.appendChild(li);
+  });
+  elements.wordList.appendChild(fragment);
+  updateBatchHeader();
+}
+
+function recordMistake(word, stageId, detail) {
+  const key = word.word;
+  const entry = state.mistakes.get(key) || {
+    word: word.word,
+    definition: word.definition,
+    count: 0,
+    lastStage: stageId,
+    lastAnswer: detail
+  };
+  entry.count += 1;
+  entry.lastStage = stageId;
+  entry.lastAnswer = detail;
+  state.mistakes.set(key, entry);
+  word.mistakes += 1;
+  updateMistakeList();
+  updateWordList();
+}
+
+function updateMistakeList() {
+  elements.mistakeList.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  const items = Array.from(state.mistakes.values()).sort((a, b) => b.count - a.count);
+  if (!items.length) {
+    const empty = document.createElement("li");
+    empty.className = "word-item";
+    empty.textContent = "暂无错题，继续保持！";
+    fragment.appendChild(empty);
+  } else {
+    items.forEach((item) => {
+      const li = document.createElement("li");
+      li.className = "word-item";
+      const name = document.createElement("span");
+      name.textContent = item.word;
+      const detail = document.createElement("span");
+      detail.className = "status retry";
+      const stageName = PRACTICE_STAGES.find((stage) => stage.id === item.lastStage)?.pill || "错题";
+      detail.textContent = `${stageName} ×${item.count}`;
+      li.title = `正确释义：${item.definition}${item.lastAnswer ? `\n最近回答：${item.lastAnswer}` : ""}`;
+      li.appendChild(name);
+      li.appendChild(detail);
+      fragment.appendChild(li);
+    });
+  }
+  elements.mistakeList.appendChild(fragment);
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+function recordCompletion(word) {
+  const now = new Date();
+  const entry = {
+    word: word.word,
+    definition: word.definition,
+    phonetic: word.phonetic || "",
+    pack: state.packName,
+    mistakes: word.mistakes,
+    completedAt: now,
+    dateKey: formatDateKey(now)
+  };
+  const existingIndex = state.dailyRecords.findIndex(
+    (item) => item.word === entry.word && item.dateKey === entry.dateKey && item.pack === entry.pack
+  );
+  if (existingIndex >= 0) {
+    state.dailyRecords[existingIndex] = entry;
+  } else {
+    state.dailyRecords.push(entry);
+  }
+}
+
+function exportTodayExcel() {
+  if (typeof XLSX === "undefined") {
+    showFeedback("未能加载 Excel 库，请稍后重试。", "danger");
+    return;
+  }
+  const todayKey = formatDateKey(new Date());
+  const records = state.dailyRecords.filter((item) => item.dateKey === todayKey);
+  if (!records.length) {
+    showFeedback("今日尚未完成任何单词，先练习一组吧！", "warning");
+    return;
+  }
+  const rows = records.map((item, index) => ({
+    序号: index + 1,
+    单词: item.word,
+    音标: item.phonetic,
+    中文释义: item.definition,
+    所属词库: item.pack,
+    错误次数: item.mistakes,
+    完成时间: formatDateTime(item.completedAt)
+  }));
+  const workbook = XLSX.utils.book_new();
+  const sheet = XLSX.utils.json_to_sheet(rows);
+  XLSX.utils.book_append_sheet(workbook, sheet, "今日学习");
+  const filename = `今日单词_${todayKey}.xlsx`;
+  XLSX.writeFile(workbook, filename);
+  showFeedback(`已导出 ${records.length} 个单词的学习记录。`, "success");
+}
+
+function exportLibraryExcel() {
+  if (typeof XLSX === "undefined") {
+    showFeedback("未能加载 Excel 库，请稍后重试。", "danger");
+    return;
+  }
+  const workbook = XLSX.utils.book_new();
+  Object.entries(WORD_PACKS).forEach(([name, words]) => {
+    const rows = words.map((item, index) => ({
+      序号: index + 1,
+      单词: item.word,
+      音标: item.phonetic || "",
+      中文释义: item.definition,
+      例句: item.example || "",
+      形近词1: item.confusions?.[0]?.word || "",
+      释义1: item.confusions?.[0]?.definition || "",
+      形近词2: item.confusions?.[1]?.word || "",
+      释义2: item.confusions?.[1]?.definition || "",
+      形近词3: item.confusions?.[2]?.word || "",
+      释义3: item.confusions?.[2]?.definition || ""
+    }));
+    const sheet = XLSX.utils.json_to_sheet(rows);
+    XLSX.utils.book_append_sheet(workbook, sheet, name.slice(0, 28));
+  });
+  const filename = `词库总览_${formatDateKey(new Date())}.xlsx`;
+  XLSX.writeFile(workbook, filename);
+  showFeedback("词库 Excel 已准备好，快去查收～", "success");
+}
+
+function formatDateKey(date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatDateTime(date) {
+  const actual = date instanceof Date ? date : new Date(date);
+  const hours = `${actual.getHours()}`.padStart(2, "0");
+  const minutes = `${actual.getMinutes()}`.padStart(2, "0");
+  return `${formatDateKey(actual)} ${hours}:${minutes}`;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,568 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --panel: rgba(15, 23, 42, 0.75);
+  --surface: rgba(255, 255, 255, 0.08);
+  --border: rgba(255, 255, 255, 0.12);
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(248, 250, 252, 0.75);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --danger: #f87171;
+  --success: #4ade80;
+  --warning: #facc15;
+  --shadow: 0 40px 80px rgba(15, 23, 42, 0.45);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "SF Pro Display", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: linear-gradient(130deg, #0f172a, #1d4ed8 55%, #22d3ee 100%);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+  padding: 32px clamp(16px, 4vw, 48px);
+}
+
+.app-shell {
+  width: min(1180px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.top-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto auto;
+  gap: 24px;
+  align-items: center;
+  padding: 20px 24px;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(24px);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand-logo {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #38bdf8, #0ea5e9);
+  font-size: 28px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 30px);
+  letter-spacing: 0.04em;
+}
+
+.brand p {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.top-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.export-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+select {
+  appearance: none;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-primary);
+  font-size: 15px;
+}
+
+button {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ghost {
+  padding: 10px 16px;
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-primary);
+  transition: background 0.2s ease;
+}
+
+.ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.export-controls .ghost {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.export-controls .ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.24);
+}
+
+.session-status {
+  text-align: right;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
+  gap: 24px;
+}
+
+.practice-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 540px;
+  padding: 24px;
+  border-radius: 32px;
+  background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.45), rgba(13, 148, 136, 0.45)),
+    rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(32px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stage-pill {
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.25);
+  color: #e0f2fe;
+  font-size: 14px;
+}
+
+.stage-tracker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stage-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+  position: relative;
+}
+
+.stage-dot.active::after,
+.stage-dot.completed::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+}
+
+.stage-dot.active {
+  background: var(--accent);
+}
+
+.stage-dot.active::after {
+  border: 2px solid rgba(56, 189, 248, 0.65);
+}
+
+.stage-dot.completed {
+  background: var(--success);
+}
+
+.stage-dot.completed::after {
+  border: 2px solid rgba(74, 222, 128, 0.65);
+}
+
+.card-progress {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.card-hero {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  gap: 16px;
+  margin: 32px 0 24px;
+  align-items: end;
+}
+
+.hero-word {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero-label {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+#word-text {
+  margin: 0;
+  font-size: clamp(42px, 6vw, 68px);
+  letter-spacing: 0.03em;
+}
+
+.hero-phonetic {
+  margin: 0;
+  font-size: 18px;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.hero-meta {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 20px;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+#stage-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.stage-description {
+  margin: 0;
+  font-size: 15px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.definition-inline {
+  display: inline-block;
+  margin-top: 6px;
+  color: #e0f2fe;
+}
+
+.card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.choice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.choice-button {
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--text-primary);
+  text-align: left;
+  line-height: 1.5;
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.choice-button:hover,
+.choice-button:focus-visible {
+  transform: translateY(-4px);
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.choice-button.correct {
+  border-color: rgba(74, 222, 128, 0.75);
+  background: rgba(74, 222, 128, 0.2);
+}
+
+.choice-button.wrong {
+  border-color: rgba(248, 113, 113, 0.75);
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.reveal-panel {
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.reveal-panel h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.reveal-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.reveal-panel li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-secondary);
+}
+
+.reveal-panel li strong {
+  color: var(--text-primary);
+}
+
+.reveal-panel li.correct {
+  color: #bbf7d0;
+}
+
+.reveal-panel li.correct strong {
+  color: #bbf7d0;
+}
+
+.tf-actions {
+  display: flex;
+  gap: 16px;
+}
+
+.action {
+  padding: 14px 26px;
+  border-radius: 999px;
+  color: #0f172a;
+  font-weight: 600;
+  transition: transform 0.18s ease, filter 0.18s ease;
+}
+
+.action.primary {
+  background: linear-gradient(135deg, #bae6fd, #38bdf8);
+}
+
+.action.danger {
+  background: linear-gradient(135deg, #fecaca, #f87171);
+}
+
+.action.success {
+  background: linear-gradient(135deg, #bbf7d0, #4ade80);
+}
+
+.action:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
+}
+
+.spelling-box {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.spelling-box label {
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.spelling-input {
+  display: flex;
+  gap: 12px;
+}
+
+#spell-input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.feedback {
+  min-height: 28px;
+  font-size: 15px;
+  color: var(--text-secondary);
+}
+
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.summary {
+  padding: 20px 22px;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+}
+
+.summary h2 {
+  margin: 0 0 16px;
+  font-size: 18px;
+}
+
+.word-list,
+.mistake-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.word-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.word-item .status {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status.pending {
+  background: rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.status.active {
+  background: rgba(56, 189, 248, 0.25);
+  color: #bae6fd;
+}
+
+.status.mastered {
+  background: rgba(74, 222, 128, 0.25);
+  color: #bbf7d0;
+}
+
+.status.retry {
+  background: rgba(248, 113, 113, 0.25);
+  color: #fecaca;
+}
+
+.summary.info ol {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 1080px) {
+  body {
+    padding: 24px;
+  }
+  .top-bar {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+  .top-controls,
+  .export-controls,
+  .session-status {
+    justify-self: stretch;
+  }
+  .top-controls,
+  .export-controls {
+    flex-wrap: wrap;
+  }
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+  .side-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .summary {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+  .top-controls {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+  .export-controls {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+  .card-hero {
+    grid-template-columns: 1fr;
+  }
+  #word-text {
+    font-size: clamp(36px, 12vw, 56px);
+  }
+}


### PR DESCRIPTION
## Summary
- add export controls and SheetJS support to output daily study logs and full GRE/考研 vocab libraries as Excel files
- rebuild the card workflow into four Baicizhan-style stages with reveal panels, spelling-choice rounds, and mistake recycling
- enrich both word packs with detailed confusion sets and tune the UI for the new reveal panel and responsive header layout

## Testing
- manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68d75ed88bf0832bb5db193edff8c474