### PR TITLE
Improve layout and add storage fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
-# PDF OCR 与清晰增强工具
+# Orpea Vocab Coach (Local Only)
 
-一个纯前端的工具页面，支持上传 PDF 文档、调节页面亮度/对比度并进行锐化处理，以便获取更清晰的图像，再通过 OCR（Tesseract.js）提取文字内容。
+Orpea Vocab Coach is a self-hosted vocabulary trainer built with React, TypeScript, and Vite. It stores all data locally using IndexedDB and never touches any remote service.
 
-## 功能特性
-- 支持 PDF 多页预览与翻页，即便是接近 300 MB 的大型文件也可在浏览器端直接处理。
-- 亮度、对比度滑块以及锐化开关，可实时增强页面清晰度。
-- 自动扫描标题生成目录，并可导出带目录的全新 PDF。
-- 一键启动 OCR，自动识别中文与英文文本。
-- 所有处理均在浏览器本地完成，文档不会上传到服务器。
+## Getting Started
 
-## 使用方式
-1. 打开 `index.html`。
-2. 点击“上传 PDF”选择文件；对于较大的 PDF（>150 MB），加载和目录分析可能需要更长时间，页面会提示进度。
-3. 根据需求调整清晰度参数。
-4. 等待系统自动生成目录预览，如需导出，点击“下载含目录 PDF”。
-5. 点击“开始 OCR 识别”查看识别结果。
+```bash
+npm install
+npm run dev
+```
+
+Build for production:
+
+```bash
+npm run build
+npm run preview
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+All assets are text-based and there are no external fonts, icons, or media files included.

--- a/index.html
+++ b/index.html
@@ -1,74 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>PDF OCR 与清晰增强工具</title>
-  <link rel="stylesheet" href="styles.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js" integrity="sha512-pP5nGthlCYcNTmAU8Go+8Nb9C/tuQCKJ3zm1OiUWRHeMMlcYLTHQi7BapYhBnVw8VrwDJ6UQnIW0EK8oBmUjOg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.worker.min.js" integrity="sha512-ZTQvr93Il59N+JGF0E3c1xfr7x0gEsx2zd71sPrcE1TVMVpSviQcFVjpi2lbY88dLChhpiZgfZzup6TkcTi6HA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tesseract.js/5.0.3/tesseract.min.js" integrity="sha512-o+nKX2aTty3H2zgpVfYdYK8qDvU/1cyAxW1NVcUshwsDHmFMCX+Hy8buRNiKpcDI39g2yXb9M1N6BbyjDyPHaQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js" integrity="sha512-92T2N3gb8ZEDJ8DdkdGeXYWAA0G6+WFUecVpyqwmePq2Faaelttzpg2b5rZeRT2TpJ7Ka5jqrZefVSxtmLDo6g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-</head>
-<body>
-  <header class="app-header">
-    <div>
-      <h1>PDF OCR 与清晰增强工具</h1>
-      <p>上传 PDF，提取文字并增强页面清晰度，助力资料整理。</p>
-    </div>
-    <label class="upload-button" for="file-input">上传 PDF</label>
-    <input type="file" id="file-input" accept="application/pdf" hidden />
-  </header>
-
-  <main class="app-main">
-    <section class="preview-panel" aria-label="PDF 预览">
-      <div class="canvas-container">
-        <canvas id="pdf-canvas" aria-label="PDF 页面预览"></canvas>
-      </div>
-      <div class="page-controls">
-        <button id="prev-page" class="ghost" disabled>上一页</button>
-        <span id="page-info" aria-live="polite">未加载</span>
-        <button id="next-page" class="ghost" disabled>下一页</button>
-      </div>
-      <div class="enhance-controls" aria-label="清晰度调节">
-        <h2>清晰度增强</h2>
-        <div class="slider-group">
-          <label for="brightness">亮度 <span id="brightness-value">0</span></label>
-          <input type="range" id="brightness" min="-50" max="50" value="0" />
-        </div>
-        <div class="slider-group">
-          <label for="contrast">对比度 <span id="contrast-value">0</span></label>
-          <input type="range" id="contrast" min="-50" max="50" value="0" />
-        </div>
-        <div class="checkbox-group">
-          <input type="checkbox" id="sharpen" />
-          <label for="sharpen">启用锐化</label>
-        </div>
-        <button id="reset-enhance" class="secondary">重置参数</button>
-      </div>
-      <button id="run-ocr" class="primary" disabled>开始 OCR 识别</button>
-    </section>
-
-    <section class="side-panel" aria-label="分析结果">
-      <div class="result-panel" aria-label="识别结果">
-        <h2>识别文字</h2>
-        <div id="ocr-status" class="status" aria-live="polite">等待上传 PDF...</div>
-        <pre id="ocr-result" tabindex="0"></pre>
-      </div>
-
-      <div class="toc-panel" aria-label="自动目录">
-        <h2>自动目录</h2>
-        <p id="toc-status" class="status">等待上传 PDF...</p>
-        <ol id="toc-list"></ol>
-        <button id="download-toc" class="primary" disabled>下载含目录 PDF</button>
-      </div>
-    </section>
-  </main>
-
-  <footer class="app-footer">
-    <p>提示：调整亮度和对比度后再执行 OCR，可获得更清晰的结果。</p>
-  </footer>
-
-  <script src="script.js" type="module"></script>
-</body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Orpea Vocab Coach</title>
+  </head>
+  <body class="bg-slate-100 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "orpea-vocab",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "dayjs": "^1.11.10",
+    "dexie": "^3.2.5",
+    "nanoid": "^4.0.2",
+    "papaparse": "^5.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.8.0",
+    "zustand": "^4.4.1"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/papaparse": "^5.3.7",
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.1",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.29",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "vitest": "^0.34.6"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react';
+import Dashboard from './pages/Dashboard';
+import Learn from './pages/Learn';
+import ImportPage from './pages/Import';
+import CardsPage from './pages/Cards';
+import SettingsPage from './pages/Settings';
+import BackupPage from './pages/Backup';
+import PrintPage from './pages/Print';
+import { useDeck } from './store/useDeck';
+
+const routes = [
+  { path: '/', label: '仪表盘', description: '今日表现、趋势与薄弱词', element: <Dashboard /> },
+  { path: '/learn', label: '学习', description: '识记 / 回忆 / 搭配 / 完形练习', element: <Learn /> },
+  { path: '/import', label: '导入', description: 'CSV / TSV 批量导入词卡', element: <ImportPage /> },
+  { path: '/cards', label: '卡片库', description: '筛选、编辑、标记全部卡片', element: <CardsPage /> },
+  { path: '/settings', label: '设置', description: '调节算法与每日目标', element: <SettingsPage /> },
+  { path: '/backup', label: '备份', description: '备份 / 恢复 / 导出复习记录', element: <BackupPage /> },
+  { path: '/print', label: '打印', description: '打印错题清单（A4 纯文本）', element: <PrintPage /> }
+];
+
+export default function App() {
+  const [path, setPath] = useState<string>(() =>
+    typeof window !== 'undefined' ? window.location.pathname || '/' : '/'
+  );
+  const { ready, loading, init, storageMode, storageError, todayNew, todayReview, todayCorrect } =
+    useDeck((state) => ({
+      ready: state.ready,
+      loading: state.loading,
+      init: state.init,
+      storageMode: state.storageMode,
+      storageError: state.storageError,
+      todayNew: state.todayNew,
+      todayReview: state.todayReview,
+      todayCorrect: state.todayCorrect
+    }));
+  const queueSummary = useDeck((state) => ({
+    due: state.queue?.due.length ?? 0,
+    fresh: state.queue?.fresh.length ?? 0,
+    session: state.queue?.session.length ?? 0
+  }));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = () => {
+      setPath(window.location.pathname || '/');
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  useEffect(() => {
+    if (!ready && !loading) {
+      init().catch((err) => console.error('Failed to initialise deck', err));
+    }
+  }, [ready, loading, init]);
+
+  const current = useMemo(() => {
+    return routes.find((r) => r.path === path) ?? routes[0];
+  }, [path]);
+
+  const handleNavigate = (nextPath: string) => {
+    if (typeof window !== 'undefined') {
+      if (window.location.pathname !== nextPath) {
+        window.history.pushState({}, '', nextPath);
+      }
+    }
+    setPath(nextPath);
+  };
+
+  const accuracy = todayReview > 0 ? Math.round((todayCorrect / todayReview) * 100) : null;
+  const content = ready ? (
+    current.element
+  ) : (
+    <div className="space-y-4 text-sm md:text-base">
+      <h2 className="text-lg font-semibold">正在准备本地数据…</h2>
+      <p className="text-slate-600">
+        首次使用请前往「导入」页面加载词表；若已导入，请稍候，系统会在本地 IndexedDB 或
+        localStorage 中恢复您的数据。
+      </p>
+      {loading && <p>正在加载词卡与记忆曲线…</p>}
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-slate-100 text-slate-900">
+      <a href="#main" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-white px-3 py-2 rounded border border-accent">
+        跳转到主要内容
+      </a>
+      <div className="mx-auto flex flex-col md:flex-row max-w-7xl">
+        <aside className="md:w-64 border-b md:border-b-0 md:border-r border-slate-200 bg-white">
+          <div className="px-5 py-6 space-y-6">
+            <div className="space-y-1">
+              <h1 className="text-2xl font-semibold tracking-tight">Orpea Vocab Coach</h1>
+              <p className="text-xs text-slate-500">完全本地 · 纯文本记忆助手</p>
+            </div>
+            <nav className="space-y-1 text-sm">
+              {routes.map((route) => {
+                const active = current.path === route.path;
+                return (
+                  <button
+                    type="button"
+                    key={route.path}
+                    onClick={() => handleNavigate(route.path)}
+                    className={`w-full text-left px-3 py-2 rounded border transition ${
+                      active
+                        ? 'border-accent bg-accent text-white'
+                        : 'border-slate-200 hover:border-accent hover:text-accent'
+                    }`}
+                    aria-current={active ? 'page' : undefined}
+                  >
+                    <span className="block font-semibold">{route.label}</span>
+                    <span className="block text-xs opacity-80">{route.description}</span>
+                  </button>
+                );
+              })}
+            </nav>
+            <div className="text-xs text-slate-600 space-y-1">
+              <p>今日新卡：{todayNew}</p>
+              <p>今日复习：{todayReview}</p>
+              <p>正确率：{accuracy !== null ? `${accuracy}%` : '—'}</p>
+            </div>
+          </div>
+        </aside>
+        <div className="flex-1 min-h-screen flex flex-col">
+          <header className="border-b border-slate-200 bg-white px-5 py-4">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">{current.label}</h2>
+                <p className="text-xs text-slate-500">{current.description}</p>
+              </div>
+              <div className="flex flex-wrap gap-3 text-xs text-slate-600">
+                <span>到期复习：{queueSummary.due}</span>
+                <span>新词待学：{queueSummary.fresh}</span>
+                <span>回炉队列：{queueSummary.session}</span>
+                <span>存储模式：{storageMode === 'indexeddb' ? 'IndexedDB' : 'localStorage'}</span>
+              </div>
+            </div>
+          </header>
+          {storageMode === 'local' && (
+            <div className="bg-warning/10 border border-warning text-warning px-5 py-3 text-sm">
+              <p>
+                浏览器禁用了 IndexedDB，已自动切换到 localStorage 运行。请避免清除浏览器缓存，或在支持
+                IndexedDB 的环境下使用以获得更可靠的持久化。
+              </p>
+              {storageError && <p className="mt-1 text-xs">错误信息：{storageError}</p>}
+            </div>
+          )}
+          <main id="main" className="flex-1 px-5 py-6 md:px-8 md:py-8 text-sm md:text-base">
+            {content}
+          </main>
+          <footer className="bg-white border-t border-slate-200 px-5 py-3 text-xs text-slate-500 text-center">
+            本项目仅在本地运行，不会上传任何数据。所有素材均为纯文本。
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/algos/leitner.ts
+++ b/src/algos/leitner.ts
@@ -1,0 +1,38 @@
+import dayjs from 'dayjs';
+
+const BOX_INTERVALS = [0, 1, 2, 4, 7, 15, 30];
+
+export interface LeitnerState {
+  leibox?: number;
+  lapses: number;
+}
+
+export function leitnerUpdate(
+  state: LeitnerState,
+  grade: 0 | 1 | 2 | 3 | 4 | 5,
+  today = dayjs()
+) {
+  let box = state.leibox ?? 1;
+  let lapses = state.lapses ?? 0;
+  const correct = grade >= 3;
+  if (correct) {
+    box = Math.min(7, box + 1);
+  } else {
+    box = Math.max(1, box - 1);
+    lapses += 1;
+  }
+  const interval = BOX_INTERVALS[box - 1] ?? 1;
+  const due = today.add(interval, 'day').toISOString();
+
+  return {
+    leibox: box,
+    lapses,
+    interval,
+    due,
+    lastGrade: grade as const
+  };
+}
+
+export function boxIntervals() {
+  return BOX_INTERVALS.slice();
+}

--- a/src/algos/sm2.ts
+++ b/src/algos/sm2.ts
@@ -1,0 +1,53 @@
+import dayjs from 'dayjs';
+
+export interface SM2State {
+  ef: number;
+  reps: number;
+  interval: number;
+  lapses: number;
+  due?: string;
+  lastGrade?: 0 | 1 | 2 | 3 | 4 | 5;
+}
+
+export function sm2Update(
+  state: SM2State,
+  grade: 0 | 1 | 2 | 3 | 4 | 5,
+  today = dayjs()
+) {
+  let { ef = 2.5, reps = 0, interval = 0, lapses = 0, due, lastGrade } = state;
+
+  if (due && interval > 0) {
+    const overdueDays = today.diff(dayjs(due), 'day');
+    if (overdueDays > interval * 2) {
+      grade = Math.min(grade, 2);
+    }
+  }
+
+  if (grade < 3) {
+    reps = 0;
+    interval = 1;
+    lapses += 1;
+  } else {
+    reps += 1;
+    if (reps === 1) interval = 1;
+    else if (reps === 2) interval = 6;
+    else interval = Math.round(interval * ef);
+
+    ef = ef + (0.1 - (5 - grade) * (0.08 + (5 - grade) * 0.02));
+    if (grade === 5 && lastGrade === 5) {
+      ef = Math.min(3.0, ef + 0.05);
+    }
+    ef = Math.max(1.3, Math.min(3.0, ef));
+  }
+
+  const nextDue = today.add(interval, 'day').toISOString();
+
+  return {
+    ef,
+    reps,
+    interval,
+    lapses,
+    due: nextDue,
+    lastGrade: grade as const
+  };
+}

--- a/src/components/CardFace.tsx
+++ b/src/components/CardFace.tsx
@@ -1,0 +1,77 @@
+import type { Card } from '../types';
+
+interface CardFaceProps {
+  card: Card;
+  reveal: boolean;
+  showPos: boolean;
+  onTogglePos: () => void;
+}
+
+export default function CardFace({ card, reveal, showPos, onTogglePos }: CardFaceProps) {
+  return (
+    <div className="bg-white border border-slate-300 rounded p-4 shadow-sm">
+      <div className="flex justify-between items-center mb-3">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight">{card.word}</h2>
+          {showPos ? (
+            <button
+              className="text-xs text-accent underline"
+              onClick={onTogglePos}
+            >
+              {card.pos}
+            </button>
+          ) : (
+            <button className="text-xs text-accent underline" onClick={onTogglePos}>
+              显示词性
+            </button>
+          )}
+        </div>
+        <div className="text-xs text-slate-500 flex flex-col items-end">
+          <span>Tags: {card.tags.join(', ') || '无'}</span>
+        </div>
+      </div>
+      {reveal ? (
+        <div className="space-y-2 text-sm leading-relaxed">
+          <section>
+            <h3 className="font-semibold">中文释义</h3>
+            <p>{card.def_zh || '—'}</p>
+          </section>
+          <section>
+            <h3 className="font-semibold">English Definition</h3>
+            <p>{card.def_en || '—'}</p>
+          </section>
+          {(card.coll_en.length > 0 || card.coll_zh.length > 0) && (
+            <section>
+              <h3 className="font-semibold">Collocations</h3>
+              <p>EN: {card.coll_en.join('; ') || '—'}</p>
+              <p>ZH: {card.coll_zh.join('; ') || '—'}</p>
+            </section>
+          )}
+          {(card.ex_en || card.ex_zh) && (
+            <section>
+              <h3 className="font-semibold">Example</h3>
+              <p>{card.ex_en || '—'}</p>
+              <p className="text-slate-600">{card.ex_zh || '—'}</p>
+            </section>
+          )}
+          {card.usage_notes && (
+            <section>
+              <h3 className="font-semibold">Usage Notes</h3>
+              <p>{card.usage_notes}</p>
+            </section>
+          )}
+          {card.mnemonic && (
+            <section>
+              <h3 className="font-semibold">Mnemonic</h3>
+              <p>{card.mnemonic}</p>
+            </section>
+          )}
+        </div>
+      ) : (
+        <div className="text-sm text-slate-500">
+          <p>点击翻面或按空格查看释义。</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ClozeQuiz.tsx
+++ b/src/components/ClozeQuiz.tsx
@@ -1,0 +1,93 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import type { Card } from '../types';
+
+interface ClozeQuizProps {
+  card: Card;
+  density: 'low' | 'mid' | 'high';
+  onResult: (result: { correct: boolean; answers: string[] }) => void;
+}
+
+interface Blank {
+  index: number;
+  word: string;
+}
+
+function selectBlanks(card: Card, density: 'low' | 'mid' | 'high'): Blank[] {
+  const words = card.ex_en.split(/\s+/);
+  const targetCount = density === 'low' ? 1 : density === 'mid' ? 2 : 3;
+  const focus = card.coll_en.map((c) => c.split(' ')[0].toLowerCase());
+  const blanks: Blank[] = [];
+  words.forEach((word, index) => {
+    const normalized = word.replace(/[^a-zA-Z]/g, '').toLowerCase();
+    if (!normalized) return;
+    if (focus.includes(normalized) && blanks.length < targetCount) {
+      blanks.push({ index, word });
+    }
+  });
+  let i = 0;
+  while (blanks.length < targetCount && i < words.length) {
+    const normalized = words[i].replace(/[^a-zA-Z]/g, '');
+    if (normalized.length > 3) {
+      blanks.push({ index: i, word: words[i] });
+    }
+    i += 1;
+  }
+  return blanks.slice(0, targetCount);
+}
+
+export default function ClozeQuiz({ card, density, onResult }: ClozeQuizProps) {
+  const blanks = useMemo(() => selectBlanks(card, density), [card, density]);
+  const [answers, setAnswers] = useState<string[]>(Array(blanks.length).fill(''));
+
+  useEffect(() => {
+    setAnswers(Array(blanks.length).fill(''));
+  }, [card.id, blanks.length]);
+
+  if (!card.ex_en) {
+    return <p className="text-sm text-slate-600">该卡片暂无例句。</p>;
+  }
+
+  const masked = card.ex_en.split(/\s+/).map((word, idx) => {
+    const blankIdx = blanks.findIndex((b) => b.index === idx);
+    if (blankIdx === -1) return word;
+    return `_____${blankIdx + 1}`;
+  });
+
+  const handleChange = (index: number, value: string) => {
+    setAnswers((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const correct = answers.every((answer, index) => {
+      const expected = blanks[index].word.replace(/[^a-zA-Z]/g, '').toLowerCase();
+      return answer.trim().toLowerCase() === expected;
+    });
+    onResult({ correct, answers });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <p className="text-sm">填空例句：</p>
+      <p className="p-3 border border-slate-300 rounded bg-white">{masked.join(' ')}</p>
+      {blanks.map((blank, index) => (
+        <div key={blank.index} className="flex items-center gap-2">
+          <label className="text-sm">空 {index + 1}</label>
+          <input
+            value={answers[index]}
+            onChange={(e) => handleChange(index, e.target.value)}
+            className="flex-1 border border-slate-300 rounded px-3 py-2"
+            placeholder={blank.word}
+          />
+        </div>
+      ))}
+      <button type="submit" className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+        提交
+      </button>
+    </form>
+  );
+}

--- a/src/components/CollocationQuiz.tsx
+++ b/src/components/CollocationQuiz.tsx
@@ -1,0 +1,73 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import type { Card } from '../types';
+
+interface Option {
+  value: string;
+  correct: boolean;
+}
+
+interface CollocationQuizProps {
+  card: Card;
+  pool: Card[];
+  onResult: (result: { correct: boolean; selected: string[] }) => void;
+}
+
+function pickDistractors(card: Card, pool: Card[], count: number): string[] {
+  const candidates = pool
+    .filter((c) => c.id !== card.id && c.tags.some((tag) => card.tags.includes(tag)))
+    .flatMap((c) => c.coll_en);
+  const shuffled = [...new Set(candidates)].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+export default function CollocationQuiz({ card, pool, onResult }: CollocationQuizProps) {
+  const options = useMemo<Option[]>(() => {
+    const distractors = pickDistractors(card, pool, Math.max(2, card.coll_en.length));
+    const combined = [...card.coll_en.map((c) => ({ value: c, correct: true })), ...distractors.map((d) => ({ value: d, correct: false }))];
+    return combined
+      .filter((opt) => opt.value)
+      .sort((a, b) => a.value.localeCompare(b.value));
+  }, [card, pool]);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => {
+    setSelected([]);
+  }, [card.id]);
+  const handleToggle = (value: string) => {
+    setSelected((prev) => (prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]));
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const correctValues = options.filter((opt) => opt.correct).map((opt) => opt.value);
+    const correct =
+      selected.length === correctValues.length &&
+      selected.every((value) => correctValues.some((cv) => cv === value));
+    onResult({ correct, selected });
+  };
+
+  if (options.length === 0) {
+    return <p className="text-sm text-slate-600">暂无搭配，跳过此题型。</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <p className="text-sm">选择该词的常见英文搭配：</p>
+      <div className="grid gap-2">
+        {options.map((option) => (
+          <label key={option.value} className="flex items-center gap-2 border border-slate-300 rounded px-3 py-2">
+            <input
+              type="checkbox"
+              checked={selected.includes(option.value)}
+              onChange={() => handleToggle(option.value)}
+            />
+            <span>{option.value}</span>
+          </label>
+        ))}
+      </div>
+      <button type="submit" className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+        提交
+      </button>
+    </form>
+  );
+}

--- a/src/components/GradeBar.tsx
+++ b/src/components/GradeBar.tsx
@@ -1,0 +1,29 @@
+interface GradeBarProps {
+  onGrade: (grade: 0 | 1 | 2 | 3 | 4 | 5) => void;
+  disabled?: boolean;
+}
+
+const labels = {
+  1: '完全不会',
+  2: '勉强',
+  3: '想一想',
+  4: '熟悉',
+  5: '非常熟'
+};
+
+export default function GradeBar({ onGrade, disabled }: GradeBarProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {[1, 2, 3, 4, 5].map((grade) => (
+        <button
+          key={grade}
+          disabled={disabled}
+          onClick={() => onGrade(grade as 1 | 2 | 3 | 4 | 5)}
+          className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent disabled:opacity-50"
+        >
+          {grade} - {(labels as any)[grade]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/RecallForm.tsx
+++ b/src/components/RecallForm.tsx
@@ -1,0 +1,51 @@
+import { FormEvent, RefObject, useEffect, useState } from 'react';
+import type { Card } from '../types';
+import { levenshtein } from '../utils/levenshtein';
+
+interface RecallFormProps {
+  card: Card;
+  typingStrict: boolean;
+  onResult: (result: { correct: boolean; answer: string; distance: number }) => void;
+  inputRef?: RefObject<HTMLInputElement>;
+}
+
+export default function RecallForm({ card, typingStrict, onResult, inputRef }: RecallFormProps) {
+  const [input, setInput] = useState('');
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    setInput('');
+    setFeedback(null);
+  }, [card.id]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const answer = input.trim();
+    const distance = levenshtein(answer, card.word);
+    const correct = typingStrict ? answer.toLowerCase() === card.word.toLowerCase() : distance <= 1;
+    setFeedback(correct ? '✓ 正确' : `✗ 正确答案：${card.word}`);
+    onResult({ correct, answer, distance });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium mb-1" htmlFor="recall-input">
+          输入英文单词
+        </label>
+        <input
+          id="recall-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="w-full border border-slate-300 rounded px-3 py-2"
+          placeholder="Type the word"
+          ref={inputRef}
+        />
+      </div>
+      <button type="submit" className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+        提交
+      </button>
+      {feedback && <div className="text-sm text-slate-600">{feedback}</div>}
+    </form>
+  );
+}

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -1,0 +1,67 @@
+import dayjs from 'dayjs';
+import type { Card, Prefs, SRSState } from '../types';
+
+export interface SessionItem {
+  card: Card;
+  srs?: SRSState;
+  availableAt: number;
+}
+
+export interface StudyQueue {
+  due: Array<{ card: Card; srs: SRSState }>;
+  fresh: Card[];
+  session: SessionItem[];
+}
+
+export function buildQueue(
+  cards: Card[],
+  srsStates: SRSState[],
+  prefs: Prefs,
+  today = dayjs()
+): StudyQueue {
+  const due: Array<{ card: Card; srs: SRSState }> = [];
+  const fresh: Card[] = [];
+  const cardMap = new Map(cards.map((card) => [card.id, card]));
+
+  const sortedSRS = [...srsStates].sort((a, b) => dayjs(a.due).valueOf() - dayjs(b.due).valueOf());
+
+  for (const state of sortedSRS) {
+    const card = cardMap.get(state.cid);
+    if (!card) continue;
+    const isDue = today.isAfter(dayjs(state.due)) || today.isSame(dayjs(state.due), 'day');
+    if (isDue && due.length < prefs.dailyReviewCap) {
+      due.push({ card, srs: state });
+    }
+  }
+
+  const learnedIds = new Set(srsStates.map((s) => s.cid));
+  for (const card of cards) {
+    if (!learnedIds.has(card.id) && fresh.length < prefs.dailyNew) {
+      fresh.push(card);
+    }
+  }
+
+  return { due, fresh, session: [] };
+}
+
+export function getNext(queue: StudyQueue, now = Date.now()) {
+  const readySessionIdx = queue.session.findIndex((item) => item.availableAt <= now);
+  if (readySessionIdx >= 0) {
+    const [item] = queue.session.splice(readySessionIdx, 1);
+    return { card: item.card, srs: item.srs, source: 'session' as const };
+  }
+  if (queue.due.length > 0) {
+    const next = queue.due.shift()!;
+    return { ...next, source: 'due' as const };
+  }
+  if (queue.fresh.length > 0) {
+    const card = queue.fresh.shift()!;
+    return { card, srs: undefined, source: 'fresh' as const };
+  }
+  return null;
+}
+
+export function pushSession(queue: StudyQueue, card: Card, srs: SRSState | undefined, delayMinutes = 10) {
+  const availableAt = dayjs().add(delayMinutes, 'minute').valueOf();
+  queue.session.push({ card, srs, availableAt });
+}

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -1,0 +1,95 @@
+import dayjs from 'dayjs';
+import type { Card, Prefs, SRSState, StudyMode, WeakFacet } from '../types';
+import { sm2Update } from '../algos/sm2';
+import { leitnerUpdate } from '../algos/leitner';
+
+const weakFacetToMode: Record<WeakFacet, StudyMode> = {
+  meaning: 'recognition',
+  collocation: 'collocation',
+  spelling: 'recall',
+  usage: 'recognition',
+  example: 'cloze'
+};
+
+const modePriority: StudyMode[] = ['recognition', 'recall', 'collocation', 'cloze'];
+
+export function getDue(states: SRSState[], today = dayjs()) {
+  return states.filter((state) => today.isSame(dayjs(state.due), 'day') || today.isAfter(dayjs(state.due)));
+}
+
+export function facetFromMode(mode: StudyMode): WeakFacet {
+  switch (mode) {
+    case 'recognition':
+      return 'meaning';
+    case 'recall':
+      return 'spelling';
+    case 'collocation':
+      return 'collocation';
+    case 'cloze':
+      return 'example';
+    default:
+      return 'meaning';
+  }
+}
+
+export function pickMode(card: Card, srs: SRSState | undefined): StudyMode {
+  if (srs?.weakFacet) {
+    return weakFacetToMode[srs.weakFacet];
+  }
+  const idx = Math.abs(card.word.length + (srs?.reps ?? 0)) % modePriority.length;
+  return modePriority[idx];
+}
+
+export interface UpdateResult {
+  srs: SRSState;
+  history: { ts: string; grade: number; mode: StudyMode; interval: number };
+  rescheduleMinutes?: number;
+}
+
+export function updateAfterGrade(
+  card: Card,
+  srs: SRSState | undefined,
+  prefs: Prefs,
+  grade: 0 | 1 | 2 | 3 | 4 | 5,
+  mode: StudyMode,
+  today = dayjs()
+): UpdateResult {
+  const base: SRSState =
+    srs ?? {
+      cid: card.id,
+      algo: prefs.algo,
+      ef: 2.5,
+      interval: 0,
+      reps: 0,
+      due: today.toISOString(),
+      lapses: 0,
+      history: []
+    };
+
+  const algo = base.algo ?? prefs.algo;
+  const update =
+    algo === 'LEITNER'
+      ? leitnerUpdate({ leibox: base.leibox, lapses: base.lapses }, grade, today)
+      : sm2Update(base, grade, today);
+
+  const weakFacet = grade < 3 ? facetFromMode(mode) : undefined;
+  const historyEntry = {
+    ts: today.toISOString(),
+    grade,
+    mode,
+    interval: update.interval ?? base.interval
+  };
+
+  const next: SRSState = {
+    ...base,
+    ...update,
+    cid: card.id,
+    algo,
+    weakFacet,
+    history: [...(base.history ?? []), historyEntry]
+  };
+
+  const rescheduleMinutes = grade >= 3 ? undefined : 10 + Math.floor(Math.random() * 11);
+
+  return { srs: next, history: historyEntry, rescheduleMinutes };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-100 text-slate-900;
+}
+
+a {
+  @apply text-accent underline;
+}
+
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/Backup.tsx
+++ b/src/pages/Backup.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { exportBackup, importBackup } from '../store/db';
+import { useDeck } from '../store/useDeck';
+import { usePrefs } from '../store/usePrefs';
+
+export default function BackupPage() {
+  const exportReviewsCsv = useDeck((state) => state.exportReviewsCsv);
+  const exportProgressJson = useDeck((state) => state.exportProgressJson);
+  const refreshQueue = useDeck((state) => state.refreshQueue);
+  const init = useDeck((state) => state.init);
+  const hydratePrefs = usePrefs((state) => state.hydrate);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleExportBackup = async () => {
+    const data = await exportBackup();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'orpea-backup.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportBackup = async (file: File) => {
+    const text = await file.text();
+    const json = JSON.parse(text);
+    await importBackup(json);
+    setMessage('备份已恢复');
+    await init();
+    refreshQueue();
+    if (json.prefs) {
+      hydratePrefs(json.prefs);
+    }
+  };
+
+  const handleExportReviews = async () => {
+    const csv = await exportReviewsCsv();
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'reviews.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportProgress = async () => {
+    const json = await exportProgressJson();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'progress.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-white border border-slate-300 rounded p-4 space-y-3">
+        <h2 className="text-lg font-semibold">备份</h2>
+        <button onClick={handleExportBackup} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+          导出备份 JSON
+        </button>
+        <button onClick={handleExportProgress} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+          导出学习进度 JSON
+        </button>
+        <button onClick={handleExportReviews} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+          导出复习记录 CSV
+        </button>
+      </section>
+
+      <section className="bg-white border border-slate-300 rounded p-4 space-y-3">
+        <h2 className="text-lg font-semibold">恢复</h2>
+        <input
+          type="file"
+          accept="application/json"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleImportBackup(file);
+          }}
+          className="border border-slate-300 rounded px-3 py-2"
+        />
+        {message && <p className="text-sm text-success">{message}</p>}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react';
+import { useDeck } from '../store/useDeck';
+import type { Card } from '../types';
+
+const fields: Array<{ key: keyof Card; label: string; type?: 'textarea' }> = [
+  { key: 'word', label: 'Word' },
+  { key: 'pos', label: '词性' },
+  { key: 'def_en', label: 'English Definition', type: 'textarea' },
+  { key: 'def_zh', label: '中文释义', type: 'textarea' },
+  { key: 'coll_en', label: 'Collocations (EN)', type: 'textarea' },
+  { key: 'coll_zh', label: '常用搭配 (中文)', type: 'textarea' },
+  { key: 'usage_notes', label: 'Usage Notes', type: 'textarea' },
+  { key: 'mnemonic', label: '记忆法', type: 'textarea' },
+  { key: 'ex_en', label: '例句 (EN)', type: 'textarea' },
+  { key: 'ex_zh', label: '例句 (中文)', type: 'textarea' },
+  { key: 'tags', label: 'Tags', type: 'textarea' }
+];
+
+export default function CardsPage() {
+  const { cards, updateCard, deleteCard } = useDeck((state) => ({
+    cards: state.cards,
+    updateCard: state.updateCard,
+    deleteCard: state.deleteCard
+  }));
+  const [search, setSearch] = useState('');
+  const [tag, setTag] = useState('');
+  const [selected, setSelected] = useState<Card | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const tags = useMemo(() => {
+    const set = new Set<string>();
+    cards.forEach((card) => card.tags.forEach((t) => set.add(t)));
+    return [...set].sort();
+  }, [cards]);
+
+  const filtered = useMemo(() => {
+    return cards.filter((card) => {
+      const matchesSearch = search
+        ? card.word.toLowerCase().includes(search.toLowerCase()) ||
+          card.def_en.toLowerCase().includes(search.toLowerCase())
+        : true;
+      const matchesTag = tag ? card.tags.includes(tag) : true;
+      return matchesSearch && matchesTag;
+    });
+  }, [cards, search, tag]);
+
+  const handleSelect = (card: Card) => {
+    setSelected(card);
+    setMessage(null);
+  };
+
+  const handleChange = (key: keyof Card, value: string) => {
+    if (!selected) return;
+    if (key === 'coll_en' || key === 'coll_zh' || key === 'tags') {
+      setSelected({ ...selected, [key]: value.split(/[;；、|]/).map((v) => v.trim()).filter(Boolean) } as Card);
+    } else {
+      setSelected({ ...selected, [key]: value } as Card);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!selected) return;
+    await updateCard(selected);
+    setMessage('保存成功');
+  };
+
+  const handleDelete = async () => {
+    if (!selected) return;
+    await deleteCard(selected.id);
+    setSelected(null);
+  };
+
+  return (
+    <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+      <section className="bg-white border border-slate-300 rounded p-4 space-y-3">
+        <h2 className="text-lg font-semibold">卡片列表</h2>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="搜索单词或释义"
+            className="border border-slate-300 rounded px-3 py-2 flex-1"
+          />
+          <select
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+            className="border border-slate-300 rounded px-3 py-2"
+          >
+            <option value="">全部标签</option>
+            {tags.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="max-h-[60vh] overflow-auto border border-slate-200">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-100 text-left">
+                <th className="px-3 py-2 border border-slate-200">Word</th>
+                <th className="px-3 py-2 border border-slate-200">POS</th>
+                <th className="px-3 py-2 border border-slate-200">中文释义</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((card) => (
+                <tr
+                  key={card.id}
+                  className="cursor-pointer hover:bg-slate-50"
+                  onClick={() => handleSelect(card)}
+                >
+                  <td className="px-3 py-2 border border-slate-200">{card.word}</td>
+                  <td className="px-3 py-2 border border-slate-200">{card.pos}</td>
+                  <td className="px-3 py-2 border border-slate-200 truncate">{card.def_zh}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="bg-white border border-slate-300 rounded p-4 space-y-3">
+        <h2 className="text-lg font-semibold">编辑</h2>
+        {!selected ? (
+          <p className="text-sm text-slate-600">选择左侧的卡片以进行编辑。</p>
+        ) : (
+          <div className="space-y-3 text-sm">
+            {fields.map((field) => (
+              <div key={field.key as string}>
+                <label className="block text-xs font-semibold mb-1">{field.label}</label>
+                {field.type === 'textarea' ? (
+                  <textarea
+                    value={Array.isArray((selected as any)[field.key]) ? (selected as any)[field.key].join('; ') : (selected as any)[field.key]}
+                    onChange={(e) => handleChange(field.key, e.target.value)}
+                    className="w-full border border-slate-300 rounded px-3 py-2 h-20"
+                  />
+                ) : (
+                  <input
+                    value={(selected as any)[field.key]}
+                    onChange={(e) => handleChange(field.key, e.target.value)}
+                    className="w-full border border-slate-300 rounded px-3 py-2"
+                  />
+                )}
+              </div>
+            ))}
+            <div className="flex gap-2">
+              <button onClick={handleSave} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+                保存
+              </button>
+              <button onClick={handleDelete} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-warning text-warning">
+                删除
+              </button>
+            </div>
+            {message && <p className="text-sm text-success">{message}</p>}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { useDeck } from '../store/useDeck';
+import { usePrefs } from '../store/usePrefs';
+
+function Bar({ value, max }: { value: number; max: number }) {
+  const width = max === 0 ? 0 : Math.round((value / max) * 100);
+  return (
+    <div className="w-full bg-slate-200 h-2 rounded">
+      <div className="h-2 bg-accent rounded" style={{ width: `${width}%` }} />
+    </div>
+  );
+}
+
+export default function Dashboard() {
+  const { cards, srs, reviews, todayNew, todayReview, todayCorrect } = useDeck((state) => state);
+  const { prefs } = usePrefs();
+
+  const correctRate = todayReview === 0 ? 0 : Math.round((todayCorrect / todayReview) * 100);
+
+  const trend = useMemo(() => {
+    const days = Array.from({ length: 7 }, (_, idx) => ({ day: idx, count: 0 }));
+    srs.forEach((state) => {
+      const due = dayjs(state.due);
+      const diff = due.diff(dayjs().startOf('day'), 'day');
+      if (diff >= 0 && diff < 7) {
+        days[diff].count += 1;
+      }
+    });
+    return days;
+  }, [srs]);
+
+  const topTags = useMemo(() => {
+    const mistakes = reviews.filter((r) => r.grade < 3).slice(-200);
+    const tagCounts = new Map<string, number>();
+    mistakes.forEach((review) => {
+      const card = cards.find((c) => c.id === review.cid);
+      if (!card) return;
+      card.tags.forEach((tag) => {
+        tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+      });
+    });
+    return [...tagCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
+  }, [reviews, cards]);
+
+  const forgettingRate = useMemo(() => {
+    const dueSoon = srs.filter((state) => dayjs(state.due).isBefore(dayjs().add(3, 'day')));
+    if (dueSoon.length === 0) return 0;
+    const highRisk = dueSoon.filter((state) => (state.lastGrade ?? 5) < 3 || (state.lapses ?? 0) > 2);
+    return Math.round((highRisk.length / dueSoon.length) * 100);
+  }, [srs]);
+
+  const maxTrend = trend.reduce((acc, cur) => Math.max(acc, cur.count), 0);
+
+  return (
+    <div className="space-y-6">
+      <section className="grid md:grid-cols-3 gap-4">
+        <div className="bg-white border border-slate-300 rounded p-4">
+          <h2 className="text-lg font-semibold">今日新卡</h2>
+          <p className="text-3xl font-bold">{todayNew} / {prefs.dailyNew}</p>
+        </div>
+        <div className="bg-white border border-slate-300 rounded p-4">
+          <h2 className="text-lg font-semibold">今日复习</h2>
+          <p className="text-3xl font-bold">{todayReview} / {prefs.dailyReviewCap}</p>
+          <p className="text-sm text-slate-600">正确率 {correctRate}%</p>
+        </div>
+        <div className="bg-white border border-slate-300 rounded p-4">
+          <h2 className="text-lg font-semibold">预估遗忘率</h2>
+          <p className="text-3xl font-bold">{forgettingRate}%</p>
+          <p className="text-xs text-slate-500">基于未来 3 天到期卡片与历史错误</p>
+        </div>
+      </section>
+
+      <section className="bg-white border border-slate-300 rounded p-4">
+        <h2 className="text-lg font-semibold mb-3">未来 7 天到期趋势</h2>
+        <div className="space-y-3">
+          {trend.map((entry) => (
+            <div key={entry.day}>
+              <div className="flex justify-between text-sm">
+                <span>{entry.day === 0 ? '今天' : `${entry.day} 天后`}</span>
+                <span>{entry.count} 张</span>
+              </div>
+              <Bar value={entry.count} max={maxTrend} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-white border border-slate-300 rounded p-4">
+        <h2 className="text-lg font-semibold mb-3">易错标签 Top 5</h2>
+        {topTags.length === 0 ? (
+          <p className="text-sm text-slate-600">暂无数据。</p>
+        ) : (
+          <ol className="list-decimal list-inside space-y-1 text-sm">
+            {topTags.map(([tag, count]) => (
+              <li key={tag}>
+                {tag}: {count} 次错误
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Import.tsx
+++ b/src/pages/Import.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { parseCsv, ParsedCardResult } from '../utils/csv';
+import { useDeck } from '../store/useDeck';
+
+export default function ImportPage() {
+  const importCards = useDeck((state) => state.importCards);
+  const [result, setResult] = useState<ParsedCardResult | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleFile = async (file: File) => {
+    setMessage(null);
+    const text = await file.text();
+    const parsed = parseCsv(text);
+    setResult(parsed);
+  };
+
+  const handleImport = async () => {
+    if (!result) return;
+    setLoading(true);
+    try {
+      const { added, updated } = await importCards(result.all);
+      setMessage(`导入成功：新增 ${added} 张，更新 ${updated} 张。`);
+      setResult(null);
+    } catch (error) {
+      setMessage(`导入失败：${(error as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-white border border-slate-300 rounded p-4 space-y-3">
+        <h2 className="text-lg font-semibold">导入 CSV/TSV</h2>
+        <p className="text-sm text-slate-600">
+          兼容列名：Word, POS, English Definition, 中文释义, Collocations (EN), 常用搭配(中文), Usage Notes, 记忆法/词根, Example (EN), 例句译文(中文), Tags。
+        </p>
+        <input
+          type="file"
+          accept=".csv,.tsv,.txt"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleFile(file);
+          }}
+          className="border border-slate-300 px-3 py-2 rounded"
+        />
+        {message && <p className="text-sm text-accent">{message}</p>}
+      </section>
+
+      {result && (
+        <section className="bg-white border border-slate-300 rounded p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-md font-semibold">预览（前 20 行）</h3>
+            <button
+              onClick={handleImport}
+              className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent"
+              disabled={loading}
+            >
+              {loading ? '导入中...' : '导入全部'}
+            </button>
+          </div>
+          {result.warnings.length > 0 && (
+            <ul className="text-sm text-warning list-disc list-inside">
+              {result.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          )}
+          <table className="w-full text-xs border border-slate-300">
+            <thead>
+              <tr className="bg-slate-100">
+                <th className="border border-slate-300 px-2 py-1">Word</th>
+                <th className="border border-slate-300 px-2 py-1">POS</th>
+                <th className="border border-slate-300 px-2 py-1">English Definition</th>
+                <th className="border border-slate-300 px-2 py-1">中文释义</th>
+                <th className="border border-slate-300 px-2 py-1">Tags</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.preview.map((card) => (
+                <tr key={card.id}>
+                  <td className="border border-slate-200 px-2 py-1">{card.word}</td>
+                  <td className="border border-slate-200 px-2 py-1">{card.pos}</td>
+                  <td className="border border-slate-200 px-2 py-1">{card.def_en}</td>
+                  <td className="border border-slate-200 px-2 py-1">{card.def_zh}</td>
+                  <td className="border border-slate-200 px-2 py-1">{card.tags.join('; ')}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import CardFace from '../components/CardFace';
+import RecallForm from '../components/RecallForm';
+import CollocationQuiz from '../components/CollocationQuiz';
+import ClozeQuiz from '../components/ClozeQuiz';
+import GradeBar from '../components/GradeBar';
+import { useDeck } from '../store/useDeck';
+import { usePrefs } from '../store/usePrefs';
+import type { StudyMode } from '../types';
+
+const modes: StudyMode[] = ['recognition', 'recall', 'collocation', 'cloze'];
+
+export default function Learn() {
+  const { current, queue, cards, grade, markWeak } = useDeck((state) => ({
+    current: state.current,
+    queue: state.queue,
+    cards: state.cards,
+    grade: state.grade,
+    markWeak: state.markWeak
+  }));
+  const { prefs } = usePrefs();
+  const [revealed, setRevealed] = useState(false);
+  const [showPos, setShowPos] = useState(false);
+  const [activeMode, setActiveMode] = useState<StudyMode>('recognition');
+  const [interactionLocked, setInteractionLocked] = useState(false);
+  const recallInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (current) {
+      setActiveMode(current.mode);
+      setRevealed(false);
+      setShowPos(false);
+      setInteractionLocked(false);
+      if (current.mode === 'recall') {
+        setTimeout(() => recallInputRef.current?.focus(), 50);
+      }
+    }
+  }, [current]);
+
+  const handleGrade = async (value: 0 | 1 | 2 | 3 | 4 | 5) => {
+    setInteractionLocked(true);
+    await grade(value);
+  };
+
+  const handleToggleMode = useCallback(() => {
+    setActiveMode((prev) => {
+      const idx = modes.indexOf(prev);
+      const next = modes[(idx + 1) % modes.length];
+      return next;
+    });
+    setRevealed(false);
+    setShowPos(false);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!current) return;
+      if (event.key === ' ') {
+        event.preventDefault();
+        setRevealed((prev) => !prev);
+      }
+      if (/^[1-5]$/.test(event.key)) {
+        event.preventDefault();
+        handleGrade(parseInt(event.key, 10) as 1 | 2 | 3 | 4 | 5);
+      }
+      if (event.key.toLowerCase() === 'c') {
+        event.preventDefault();
+        handleToggleMode();
+      }
+      if (event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        markWeak();
+      }
+      if (event.key === '/') {
+        event.preventDefault();
+        recallInputRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [current, handleToggleMode, markWeak]);
+
+  const queueInfo = useMemo(() => {
+    if (!queue) return { due: 0, fresh: 0, session: 0 };
+    return {
+      due: queue.due.length,
+      fresh: queue.fresh.length,
+      session: queue.session.length
+    };
+  }, [queue]);
+
+  if (!current) {
+    return (
+      <div className="space-y-4">
+        <p>今日任务完成！如果刚导入，请前往 Import 页面加载卡片。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="flex flex-wrap gap-4 text-xs text-slate-600">
+        <span>今日队列：到期 {queueInfo.due} | 新卡 {queueInfo.fresh} | 回炉 {queueInfo.session}</span>
+        <span>当前题型：{activeMode}</span>
+        <span>快捷键：Space 翻面 / 1-5 评分 / C 切题型 / F 标记 / / 聚焦输入</span>
+      </section>
+
+      {activeMode === 'recognition' && (
+        <CardFace
+          card={current.card}
+          reveal={revealed}
+          showPos={showPos}
+          onTogglePos={() => setShowPos((prev) => !prev)}
+        />
+      )}
+
+      {activeMode === 'recall' && (
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="bg-white border border-slate-300 rounded p-4 space-y-2">
+            <h2 className="font-semibold">中文释义</h2>
+            <p>{current.card.def_zh || '—'}</p>
+            {current.card.coll_zh.length > 0 && (
+              <p className="text-sm text-slate-600">常用搭配：{current.card.coll_zh.slice(0, 2).join('；')}</p>
+            )}
+          </div>
+          <RecallForm
+            card={current.card}
+            typingStrict={prefs.typingStrict}
+            onResult={() => {
+              setRevealed(true);
+              setInteractionLocked(false);
+            }}
+            inputRef={recallInputRef}
+          />
+        </div>
+      )}
+
+      {activeMode === 'collocation' && (
+        <CollocationQuiz
+          card={current.card}
+          pool={cards}
+          onResult={(result) => {
+            setInteractionLocked(false);
+            setRevealed(true);
+            if (!result.correct) {
+              markWeak();
+            }
+          }}
+        />
+      )}
+
+      {activeMode === 'cloze' && (
+        <ClozeQuiz
+          card={current.card}
+          density={prefs.clozeDensity}
+          onResult={(result) => {
+            setInteractionLocked(false);
+            setRevealed(true);
+            if (!result.correct) {
+              markWeak();
+            }
+          }}
+        />
+      )}
+
+      {revealed && (
+        <div className="space-y-3">
+          <h3 className="font-semibold">评分</h3>
+          <GradeBar onGrade={handleGrade} disabled={interactionLocked} />
+        </div>
+      )}
+
+      {revealed && activeMode !== 'recognition' && (
+        <CardFace
+          card={current.card}
+          reveal={true}
+          showPos={showPos}
+          onTogglePos={() => setShowPos((prev) => !prev)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/Print.tsx
+++ b/src/pages/Print.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { useDeck } from '../store/useDeck';
+
+export default function PrintPage() {
+  const { reviews, cards, srs } = useDeck((state) => ({
+    reviews: state.reviews,
+    cards: state.cards,
+    srs: state.srs
+  }));
+
+  const recentMistakes = useMemo(() => {
+    const oneWeekAgo = dayjs().subtract(7, 'day');
+    return reviews
+      .filter((review) => review.grade < 3 && dayjs(review.ts).isAfter(oneWeekAgo))
+      .map((review) => ({
+        review,
+        card: cards.find((card) => card.id === review.cid)
+      }))
+      .filter((entry) => entry.card);
+  }, [reviews, cards]);
+
+  const facetCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    srs.forEach((state) => {
+      if (state.weakFacet) {
+        counts.set(state.weakFacet, (counts.get(state.weakFacet) ?? 0) + 1);
+      }
+    });
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [srs]);
+
+  return (
+    <div className="space-y-4 text-sm">
+      <style>{`@media print { body { background: #fff; color: #000; } table { page-break-inside: avoid; } }`}</style>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">本周错题</h2>
+        <table className="w-full border border-slate-300">
+          <thead>
+            <tr className="bg-slate-100">
+              <th className="border border-slate-300 px-2 py-1">单词</th>
+              <th className="border border-slate-300 px-2 py-1">中文释义</th>
+              <th className="border border-slate-300 px-2 py-1">错误时间</th>
+              <th className="border border-slate-300 px-2 py-1">例句</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recentMistakes.length === 0 ? (
+              <tr>
+                <td className="px-2 py-2" colSpan={4}>
+                  最近一周没有错题。
+                </td>
+              </tr>
+            ) : (
+              recentMistakes.map(({ review, card }) => (
+                <tr key={review.ts + review.cid}>
+                  <td className="border border-slate-200 px-2 py-1">{card!.word}</td>
+                  <td className="border border-slate-200 px-2 py-1">{card!.def_zh}</td>
+                  <td className="border border-slate-200 px-2 py-1">{dayjs(review.ts).format('YYYY-MM-DD HH:mm')}</td>
+                  <td className="border border-slate-200 px-2 py-1">{card!.ex_en}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">薄弱面分布</h2>
+        {facetCounts.length === 0 ? (
+          <p>暂无弱项数据。</p>
+        ) : (
+          <table className="w-full border border-slate-300">
+            <thead>
+              <tr className="bg-slate-100">
+                <th className="border border-slate-300 px-2 py-1">薄弱面</th>
+                <th className="border border-slate-300 px-2 py-1">数量</th>
+              </tr>
+            </thead>
+            <tbody>
+              {facetCounts.map(([facet, count]) => (
+                <tr key={facet}>
+                  <td className="border border-slate-200 px-2 py-1">{facet}</td>
+                  <td className="border border-slate-200 px-2 py-1">{count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { usePrefs } from '../store/usePrefs';
+
+export default function SettingsPage() {
+  const { prefs, setPrefs, reset } = usePrefs();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSave = () => {
+    setPrefs({ ...prefs });
+    setMessage('设置已保存');
+  };
+
+  return (
+    <div className="bg-white border border-slate-300 rounded p-4 space-y-4 max-w-2xl">
+      <h2 className="text-lg font-semibold">学习设置</h2>
+      <div className="grid md:grid-cols-2 gap-4 text-sm">
+        <label className="space-y-1">
+          <span>每日新词目标</span>
+          <input
+            type="number"
+            value={prefs.dailyNew}
+            onChange={(e) => setPrefs({ dailyNew: Number(e.target.value) })}
+            className="border border-slate-300 rounded px-3 py-2"
+          />
+        </label>
+        <label className="space-y-1">
+          <span>每日复习上限</span>
+          <input
+            type="number"
+            value={prefs.dailyReviewCap}
+            onChange={(e) => setPrefs({ dailyReviewCap: Number(e.target.value) })}
+            className="border border-slate-300 rounded px-3 py-2"
+          />
+        </label>
+        <label className="space-y-1">
+          <span>默认算法</span>
+          <select
+            value={prefs.algo}
+            onChange={(e) => setPrefs({ algo: e.target.value as 'SM2' | 'LEITNER' })}
+            className="border border-slate-300 rounded px-3 py-2"
+          >
+            <option value="SM2">SM-2</option>
+            <option value="LEITNER">Leitner</option>
+          </select>
+        </label>
+        <label className="space-y-1">
+          <span>拼写严格模式</span>
+          <select
+            value={prefs.typingStrict ? 'strict' : 'lenient'}
+            onChange={(e) => setPrefs({ typingStrict: e.target.value === 'strict' })}
+            className="border border-slate-300 rounded px-3 py-2"
+          >
+            <option value="lenient">宽松（允许编辑距离 ≤ 1）</option>
+            <option value="strict">严格（必须完全匹配）</option>
+          </select>
+        </label>
+        <label className="space-y-1">
+          <span>完形填空密度</span>
+          <select
+            value={prefs.clozeDensity}
+            onChange={(e) => setPrefs({ clozeDensity: e.target.value as 'low' | 'mid' | 'high' })}
+            className="border border-slate-300 rounded px-3 py-2"
+          >
+            <option value="low">低</option>
+            <option value="mid">中</option>
+            <option value="high">高</option>
+          </select>
+        </label>
+      </div>
+      <div className="flex gap-2">
+        <button onClick={handleSave} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-accent">
+          保存
+        </button>
+        <button onClick={reset} className="px-3 py-1 border border-slate-400 rounded bg-white hover:border-warning text-warning">
+          重置默认值
+        </button>
+      </div>
+      {message && <p className="text-sm text-success">{message}</p>}
+    </div>
+  );
+}

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,0 +1,311 @@
+import Dexie, { Table } from 'dexie';
+import type { Card, Prefs, ReviewRecord, SRSState } from '../types';
+
+export type StorageMode = 'indexeddb' | 'local';
+
+export class OrpeaDB extends Dexie {
+  cards!: Table<Card, string>;
+  srs!: Table<SRSState, string>;
+  prefs!: Table<Prefs, string>;
+  reviews!: Table<ReviewRecord, number>;
+
+  constructor() {
+    super('orpea_vocab');
+    this.version(1).stores({
+      cards: 'id, word, pos, *tags',
+      srs: 'cid, algo, due, weakFacet',
+      prefs: '++id',
+      reviews: '++id, cid, ts'
+    });
+  }
+}
+
+export const DEFAULT_PREFS: Prefs = {
+  dailyNew: 20,
+  dailyReviewCap: 120,
+  algo: 'SM2',
+  typingStrict: false,
+  clozeDensity: 'mid'
+};
+
+type LocalSnapshot = {
+  cards: Card[];
+  srs: SRSState[];
+  prefs: Prefs;
+  reviews: ReviewRecord[];
+};
+
+type StorageSnapshot = LocalSnapshot & {
+  mode: StorageMode;
+  error?: string;
+};
+
+const localKey = 'orpea_vocab_snapshot';
+const dexie = new OrpeaDB();
+let mode: StorageMode = 'indexeddb';
+let lastError: string | undefined;
+let memorySnapshot: LocalSnapshot | null = null;
+let triedOpen = false;
+
+function setLocalMode(err: unknown) {
+  mode = 'local';
+  lastError = err instanceof Error ? err.message : String(err);
+}
+
+function deepCopy<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function baseSnapshot(): LocalSnapshot {
+  return {
+    cards: [],
+    srs: [],
+    prefs: { ...DEFAULT_PREFS },
+    reviews: []
+  };
+}
+
+function readLocal(): LocalSnapshot {
+  const storage = getLocalStorage();
+  if (!storage) {
+    if (!memorySnapshot) memorySnapshot = baseSnapshot();
+    return deepCopy(memorySnapshot);
+  }
+  const raw = storage.getItem(localKey);
+  if (!raw) {
+    return baseSnapshot();
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<LocalSnapshot>;
+    return {
+      cards: Array.isArray(parsed.cards) ? parsed.cards : [],
+      srs: Array.isArray(parsed.srs) ? parsed.srs : [],
+      prefs: { ...DEFAULT_PREFS, ...(parsed.prefs ?? {}) },
+      reviews: Array.isArray(parsed.reviews) ? parsed.reviews : []
+    };
+  } catch {
+    return baseSnapshot();
+  }
+}
+
+function writeLocal(next: LocalSnapshot) {
+  const copy = deepCopy(next);
+  const storage = getLocalStorage();
+  if (storage) {
+    storage.setItem(localKey, JSON.stringify(copy));
+  }
+  memorySnapshot = copy;
+}
+
+function updateLocal(mutator: (snapshot: LocalSnapshot) => void) {
+  const snapshot = readLocal();
+  mutator(snapshot);
+  writeLocal(snapshot);
+}
+
+async function ensureDexieOpen() {
+  if (mode === 'local') return;
+  if (dexie.isOpen()) return;
+  if (triedOpen) return;
+  triedOpen = true;
+  try {
+    await dexie.open();
+  } catch (err) {
+    setLocalMode(err);
+  }
+}
+
+async function withDexie<T>(task: (db: OrpeaDB) => Promise<T>): Promise<T | undefined> {
+  if (mode === 'local') return undefined;
+  await ensureDexieOpen();
+  if (mode === 'local') return undefined;
+  try {
+    const result = await task(dexie);
+    lastError = undefined;
+    return result;
+  } catch (err) {
+    setLocalMode(err);
+    return undefined;
+  }
+}
+
+export function getStorageStatus(): { mode: StorageMode; error?: string } {
+  return { mode, error: lastError };
+}
+
+function normaliseSnapshot(snapshot: LocalSnapshot): LocalSnapshot {
+  return {
+    cards: snapshot.cards ?? [],
+    srs: snapshot.srs ?? [],
+    prefs: { ...DEFAULT_PREFS, ...(snapshot.prefs ?? DEFAULT_PREFS) },
+    reviews: snapshot.reviews ?? []
+  };
+}
+
+export async function loadSnapshot(): Promise<StorageSnapshot> {
+  const dexieSnapshot = await withDexie(async (db) => {
+    const [cards, srs, prefsList, reviews] = await Promise.all([
+      db.cards.toArray(),
+      db.srs.toArray(),
+      db.prefs.toArray(),
+      db.reviews.toArray()
+    ]);
+    const prefs = prefsList[0] ?? { ...DEFAULT_PREFS };
+    const snapshot: LocalSnapshot = normaliseSnapshot({ cards, srs, prefs, reviews });
+    writeLocal(snapshot);
+    return snapshot;
+  });
+
+  if (dexieSnapshot) {
+    return { ...dexieSnapshot, mode: 'indexeddb' };
+  }
+
+  const local = normaliseSnapshot(readLocal());
+  return { ...local, mode, error: lastError };
+}
+
+export async function savePrefs(prefs: Prefs) {
+  const merged = { ...DEFAULT_PREFS, ...prefs };
+  updateLocal((snapshot) => {
+    snapshot.prefs = merged;
+  });
+  await withDexie(async (db) => {
+    await db.prefs.clear();
+    await db.prefs.add(merged);
+  });
+}
+
+export async function upsertCards(cards: Card[]) {
+  if (!cards.length) return;
+  updateLocal((snapshot) => {
+    const map = new Map(snapshot.cards.map((card) => [card.id, card]));
+    for (const card of cards) {
+      map.set(card.id, card);
+    }
+    snapshot.cards = Array.from(map.values());
+  });
+  await withDexie(async (db) => {
+    await db.cards.bulkPut(cards);
+  });
+}
+
+export async function removeCardAndState(id: string) {
+  updateLocal((snapshot) => {
+    snapshot.cards = snapshot.cards.filter((card) => card.id !== id);
+    snapshot.srs = snapshot.srs.filter((state) => state.cid !== id);
+  });
+  await withDexie(async (db) => {
+    await db.transaction('rw', db.cards, db.srs, async () => {
+      await db.cards.delete(id);
+      await db.srs.delete(id);
+    });
+  });
+}
+
+export async function saveSrsState(state: SRSState) {
+  updateLocal((snapshot) => {
+    const index = snapshot.srs.findIndex((item) => item.cid === state.cid);
+    if (index >= 0) {
+      snapshot.srs[index] = state;
+    } else {
+      snapshot.srs.push(state);
+    }
+  });
+  await withDexie(async (db) => {
+    await db.srs.put(state);
+  });
+}
+
+export async function removeSrsState(id: string) {
+  updateLocal((snapshot) => {
+    snapshot.srs = snapshot.srs.filter((state) => state.cid !== id);
+  });
+  await withDexie(async (db) => {
+    await db.srs.delete(id);
+  });
+}
+
+export async function appendReview(record: ReviewRecord) {
+  updateLocal((snapshot) => {
+    snapshot.reviews.push(record);
+  });
+  await withDexie(async (db) => {
+    await db.reviews.add(record);
+  });
+}
+
+export async function replaceAll(payload: LocalSnapshot) {
+  const normalized = normaliseSnapshot(payload);
+  writeLocal(normalized);
+  await withDexie(async (db) => {
+    await db.transaction('rw', db.cards, db.srs, db.prefs, db.reviews, async () => {
+      await db.cards.clear();
+      await db.srs.clear();
+      await db.prefs.clear();
+      await db.reviews.clear();
+      if (normalized.cards.length) await db.cards.bulkAdd(normalized.cards);
+      if (normalized.srs.length) await db.srs.bulkAdd(normalized.srs);
+      await db.prefs.add(normalized.prefs);
+      if (normalized.reviews.length) await db.reviews.bulkAdd(normalized.reviews);
+    });
+  });
+}
+
+export async function fetchReviews(): Promise<ReviewRecord[]> {
+  const dexieReviews = await withDexie(async (db) => {
+    const reviews = await db.reviews.toArray();
+    updateLocal((snapshot) => {
+      snapshot.reviews = reviews;
+    });
+    return reviews;
+  });
+  if (dexieReviews) return dexieReviews;
+  return readLocal().reviews;
+}
+
+export async function fetchCards(): Promise<Card[]> {
+  const dexieCards = await withDexie(async (db) => {
+    const cards = await db.cards.toArray();
+    updateLocal((snapshot) => {
+      snapshot.cards = cards;
+    });
+    return cards;
+  });
+  if (dexieCards) return dexieCards;
+  return readLocal().cards;
+}
+
+export async function fetchSrs(): Promise<SRSState[]> {
+  const dexieSrs = await withDexie(async (db) => {
+    const srs = await db.srs.toArray();
+    updateLocal((snapshot) => {
+      snapshot.srs = srs;
+    });
+    return srs;
+  });
+  if (dexieSrs) return dexieSrs;
+  return readLocal().srs;
+}
+
+export async function exportBackup(): Promise<LocalSnapshot> {
+  const snapshot = await loadSnapshot();
+  return {
+    cards: snapshot.cards,
+    srs: snapshot.srs,
+    prefs: snapshot.prefs,
+    reviews: snapshot.reviews
+  };
+}
+
+export async function importBackup(payload: LocalSnapshot) {
+  await replaceAll(payload);
+}

--- a/src/store/useDeck.ts
+++ b/src/store/useDeck.ts
@@ -1,0 +1,269 @@
+import create from 'zustand';
+import dayjs from 'dayjs';
+import type { Card, ReviewRecord, SRSState, StudyMode } from '../types';
+import {
+  appendReview,
+  exportBackup,
+  fetchReviews,
+  getStorageStatus,
+  loadSnapshot,
+  removeCardAndState,
+  saveSrsState,
+  upsertCards
+} from './db';
+import { buildQueue, getNext, pushSession, StudyQueue } from '../core/queue';
+import { facetFromMode, pickMode, updateAfterGrade } from '../core/scheduler';
+import { usePrefs } from './usePrefs';
+import { newId } from '../utils/id';
+import { compareInsensitive } from '../utils/str';
+
+interface CurrentItem {
+  card: Card;
+  srs?: SRSState;
+  mode: StudyMode;
+  source: 'due' | 'fresh' | 'session';
+}
+
+interface DeckState {
+  ready: boolean;
+  loading: boolean;
+  cards: Card[];
+  srs: SRSState[];
+  reviews: ReviewRecord[];
+  queue: StudyQueue | null;
+  current?: CurrentItem | null;
+  todayNew: number;
+  todayReview: number;
+  todayCorrect: number;
+  storageMode: 'indexeddb' | 'local';
+  storageError?: string;
+  init: () => Promise<void>;
+  refreshQueue: () => void;
+  nextCard: () => void;
+  grade: (grade: 0 | 1 | 2 | 3 | 4 | 5) => Promise<void>;
+  importCards: (cards: Card[]) => Promise<{ added: number; updated: number }>;
+  updateCard: (card: Card) => Promise<void>;
+  deleteCard: (id: string) => Promise<void>;
+  exportReviewsCsv: () => Promise<string>;
+  exportProgressJson: () => Promise<string>;
+  markWeak: () => Promise<void>;
+}
+
+function formatCsv(reviews: ReviewRecord[]): string {
+  const header = 'cid,grade,mode,ts,interval';
+  const rows = reviews
+    .map((r) => `${r.cid},${r.grade},${r.mode},${r.ts},${r.interval}`)
+    .join('\n');
+  return `${header}\n${rows}`;
+}
+
+export const useDeck = create<DeckState>((set, get) => ({
+  ready: false,
+  loading: false,
+  cards: [],
+  srs: [],
+  reviews: [],
+  queue: null,
+  current: null,
+  todayNew: 0,
+  todayReview: 0,
+  todayCorrect: 0,
+  storageMode: 'indexeddb',
+  storageError: undefined,
+  init: async () => {
+    set({ loading: true });
+    const snapshot = await loadSnapshot();
+    usePrefs.getState().hydrate(snapshot.prefs);
+    const queue = buildQueue(snapshot.cards, snapshot.srs, snapshot.prefs);
+    set({
+      cards: snapshot.cards,
+      srs: snapshot.srs,
+      reviews: snapshot.reviews,
+      queue,
+      loading: false,
+      ready: true,
+      todayNew: 0,
+      todayReview: 0,
+      todayCorrect: 0,
+      storageMode: snapshot.mode,
+      storageError: snapshot.error
+    });
+    get().nextCard();
+  },
+  refreshQueue: () => {
+    const { cards, srs } = get();
+    const prefs = usePrefs.getState().prefs;
+    const queue = buildQueue(cards, srs, prefs);
+    set({ queue });
+  },
+  nextCard: () => {
+    const state = get();
+    const queue = state.queue;
+    if (!queue) return;
+    const next = getNext(queue);
+    if (!next) {
+      set({ current: null });
+      return;
+    }
+    const mode = pickMode(next.card, next.srs);
+    set({
+      current: { card: next.card, srs: next.srs, mode, source: next.source },
+      queue: {
+        due: [...queue.due],
+        fresh: [...queue.fresh],
+        session: [...queue.session]
+      }
+    });
+  },
+  grade: async (grade) => {
+    const state = get();
+    const current = state.current;
+    if (!current) return;
+    const prefs = usePrefs.getState().prefs;
+    const today = dayjs();
+    const { srs: updated, history, rescheduleMinutes } = updateAfterGrade(
+      current.card,
+      current.srs,
+      prefs,
+      grade,
+      current.mode,
+      today
+    );
+    await saveSrsState(updated);
+    await appendReview({
+      cid: updated.cid,
+      grade,
+      mode: current.mode,
+      ts: history.ts,
+      interval: history.interval
+    });
+
+    set((prev) => {
+      const other = prev.srs.filter((s) => s.cid !== updated.cid);
+      const reviews = [
+        ...prev.reviews,
+        { cid: updated.cid, grade, mode: current.mode, ts: history.ts, interval: history.interval }
+      ];
+      const todayReview = prev.todayReview + 1;
+      const todayCorrect = prev.todayCorrect + (grade >= 3 ? 1 : 0);
+      const wasNew = !current.srs;
+      const todayNew = prev.todayNew + (wasNew ? 1 : 0);
+      const queue = prev.queue
+        ? {
+            due: [...prev.queue.due],
+            fresh: [...prev.queue.fresh],
+            session: [...prev.queue.session]
+          }
+        : { due: [], fresh: [], session: [] };
+      if (grade < 3) {
+        pushSession(queue, current.card, updated, rescheduleMinutes ?? 10);
+      }
+      const status = getStorageStatus();
+      return {
+        srs: [...other, updated],
+        reviews,
+        todayReview,
+        todayCorrect,
+        todayNew,
+        queue,
+        current: null,
+        storageMode: status.mode,
+        storageError: status.error
+      };
+    });
+
+    get().nextCard();
+  },
+  importCards: async (incoming) => {
+    if (!incoming.length) return { added: 0, updated: 0 };
+    const existingCards = get().cards;
+    const key = (card: Card) => `${card.word.toLowerCase()}|${card.pos.toLowerCase()}`;
+    const cardIndex = new Map(existingCards.map((card) => [key(card), card]));
+    let added = 0;
+    let updatedCount = 0;
+    const toPersist: Card[] = [];
+    for (const card of incoming) {
+      const existing = cardIndex.get(key(card));
+      if (existing) {
+        const updatedCard: Card = { ...card, id: existing.id };
+        cardIndex.set(key(updatedCard), updatedCard);
+        toPersist.push(updatedCard);
+        updatedCount += 1;
+      } else {
+        const newCard: Card = { ...card, id: card.id || newId() };
+        cardIndex.set(key(newCard), newCard);
+        toPersist.push(newCard);
+        added += 1;
+      }
+    }
+
+    await upsertCards(toPersist);
+
+    const cards = Array.from(cardIndex.values());
+    const status = getStorageStatus();
+    set({ cards, storageMode: status.mode, storageError: status.error });
+    get().refreshQueue();
+    return { added, updated: updatedCount };
+  },
+  updateCard: async (card: Card) => {
+    await upsertCards([card]);
+    const status = getStorageStatus();
+    set((prev) => ({
+      cards: prev.cards.map((existing) => (existing.id === card.id ? card : existing)),
+      storageMode: status.mode,
+      storageError: status.error
+    }));
+  },
+  deleteCard: async (id: string) => {
+    await removeCardAndState(id);
+    const status = getStorageStatus();
+    const cards = get().cards.filter((card) => card.id !== id);
+    const srs = get().srs.filter((state) => state.cid !== id);
+    set({ cards, srs, storageMode: status.mode, storageError: status.error });
+    get().refreshQueue();
+  },
+  exportReviewsCsv: async () => {
+    const reviews = await fetchReviews();
+    const status = getStorageStatus();
+    set((prev) => ({
+      ...prev,
+      storageMode: status.mode,
+      storageError: status.error
+    }));
+    return formatCsv(reviews);
+  },
+  exportProgressJson: async () => {
+    const payload = await exportBackup();
+    const status = getStorageStatus();
+    set((prev) => ({
+      ...prev,
+      storageMode: status.mode,
+      storageError: status.error
+    }));
+    return JSON.stringify(payload, null, 2);
+  },
+  markWeak: async () => {
+    const { current } = get();
+    if (!current?.srs) return;
+    const facet = facetFromMode(current.mode);
+    const updated = { ...current.srs, weakFacet: facet };
+    await saveSrsState(updated);
+    const status = getStorageStatus();
+    set((prev) => ({
+      srs: prev.srs.map((state) => (state.cid === updated.cid ? updated : state)),
+      current: current ? { ...current, srs: updated } : current,
+      storageMode: status.mode,
+      storageError: status.error
+    }));
+  }
+}));
+
+export function getCardById(id: string) {
+  const { cards } = useDeck.getState();
+  return cards.find((card) => card.id === id);
+}
+
+export function getCardsByTag(tag: string) {
+  const { cards } = useDeck.getState();
+  return cards.filter((card) => card.tags.some((t) => compareInsensitive(t, tag) === 0));
+}

--- a/src/store/usePrefs.ts
+++ b/src/store/usePrefs.ts
@@ -1,0 +1,29 @@
+import create from 'zustand';
+import type { Prefs } from '../types';
+import { DEFAULT_PREFS, savePrefs } from './db';
+
+interface PrefsState {
+  prefs: Prefs;
+  hydrate: (prefs: Prefs) => void;
+  setPrefs: (prefs: Partial<Prefs>) => void;
+  reset: () => void;
+}
+
+export const usePrefs = create<PrefsState>((set) => ({
+  prefs: DEFAULT_PREFS,
+  hydrate: (prefs) => {
+    const next = { ...DEFAULT_PREFS, ...prefs };
+    set({ prefs: next });
+  },
+  setPrefs: (partial) => {
+    set((state) => {
+      const next = { ...state.prefs, ...partial };
+      savePrefs(next);
+      return { prefs: next };
+    });
+  },
+  reset: () => {
+    savePrefs(DEFAULT_PREFS);
+    set({ prefs: DEFAULT_PREFS });
+  }
+}));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,48 @@
+export type SRSAlgo = 'SM2' | 'LEITNER';
+export type WeakFacet = 'meaning' | 'collocation' | 'spelling' | 'usage' | 'example';
+export type StudyMode = 'recognition' | 'recall' | 'collocation' | 'cloze';
+
+export interface Card {
+  id: string;
+  word: string;
+  pos: string;
+  def_en: string;
+  def_zh: string;
+  coll_en: string[];
+  coll_zh: string[];
+  usage_notes: string;
+  mnemonic: string;
+  ex_en: string;
+  ex_zh: string;
+  tags: string[];
+}
+
+export interface SRSState {
+  cid: string;
+  algo: SRSAlgo;
+  ef: number;
+  interval: number;
+  reps: number;
+  due: string;
+  leibox?: number;
+  lapses: number;
+  lastGrade?: 0 | 1 | 2 | 3 | 4 | 5;
+  history: Array<{ ts: string; grade: number; mode: StudyMode; interval: number }>;
+  weakFacet?: WeakFacet;
+}
+
+export interface Prefs {
+  dailyNew: number;
+  dailyReviewCap: number;
+  algo: SRSAlgo;
+  typingStrict: boolean;
+  clozeDensity: 'low' | 'mid' | 'high';
+}
+
+export interface ReviewRecord {
+  cid: string;
+  grade: number;
+  mode: StudyMode;
+  ts: string;
+  interval: number;
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,92 @@
+import Papa from 'papaparse';
+import type { Card } from '../types';
+import { normalizeHeader, splitMulti } from './str';
+import { newId } from './id';
+
+const aliases: Record<string, keyof Card> = {
+  word: 'word',
+  'pos': 'pos',
+  'part of speech': 'pos',
+  'english definition': 'def_en',
+  'definition en': 'def_en',
+  '中文释义': 'def_zh',
+  '中文 释义': 'def_zh',
+  'chinese definition': 'def_zh',
+  'collocations (en)': 'coll_en',
+  'collocations': 'coll_en',
+  '常用搭配(中文)': 'coll_zh',
+  '常用搭配': 'coll_zh',
+  'collocations (zh)': 'coll_zh',
+  'usage notes': 'usage_notes',
+  '记忆法/词根': 'mnemonic',
+  'mnemonic': 'mnemonic',
+  'example (en)': 'ex_en',
+  'example en': 'ex_en',
+  '例句译文(中文)': 'ex_zh',
+  '例句译文': 'ex_zh',
+  'tags': 'tags'
+};
+
+export interface ParsedCardResult {
+  preview: Card[];
+  all: Card[];
+  warnings: string[];
+}
+
+function mapRow(row: Record<string, string>): Card {
+  const card: Card = {
+    id: newId(),
+    word: '',
+    pos: '',
+    def_en: '',
+    def_zh: '',
+    coll_en: [],
+    coll_zh: [],
+    usage_notes: '',
+    mnemonic: '',
+    ex_en: '',
+    ex_zh: '',
+    tags: []
+  };
+
+  Object.entries(row).forEach(([rawKey, value]) => {
+    const key = normalizeHeader(rawKey);
+    const mapped = aliases[key];
+    if (!mapped) return;
+    const val = (value ?? '').trim();
+    if (mapped === 'coll_en' || mapped === 'coll_zh' || mapped === 'tags') {
+      (card[mapped] as string[]) = splitMulti(val);
+    } else {
+      (card as any)[mapped] = val;
+    }
+  });
+  return card;
+}
+
+export function parseCsv(text: string): ParsedCardResult {
+  const warnings: string[] = [];
+  const { data } = Papa.parse<Record<string, string>>(text, {
+    header: true,
+    skipEmptyLines: 'greedy',
+    transformHeader: normalizeHeader,
+    delimiter: ''
+  });
+  const cards = data
+    .filter((row) => Object.values(row).some((value) => value && value.trim().length > 0))
+    .map((row) => mapRow(row));
+
+  cards.forEach((card) => {
+    if (!card.word || !card.pos) {
+      warnings.push(`Card ${card.word || card.id} is missing Word or POS.`);
+    }
+    if (!card.def_en || !card.def_zh) {
+      warnings.push(`Card ${card.word || card.id} missing definition.`);
+    }
+  });
+
+  return {
+    preview: cards.slice(0, 20),
+    all: cards,
+    warnings
+  };
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,21 @@
+import dayjs from 'dayjs';
+
+export function todayISO() {
+  return dayjs().startOf('day').toISOString();
+}
+
+export function isOverdue(due: string) {
+  return dayjs().isAfter(dayjs(due));
+}
+
+export function diffInDays(from: string, to: string) {
+  return dayjs(to).diff(dayjs(from), 'day');
+}
+
+export function addMinutes(date: string | number, mins: number) {
+  return dayjs(date).add(mins, 'minute').valueOf();
+}
+
+export function addDaysISO(date: string, days: number) {
+  return dayjs(date).add(days, 'day').toISOString();
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,5 @@
+import { nanoid } from 'nanoid';
+
+export function newId() {
+  return nanoid();
+}

--- a/src/utils/levenshtein.ts
+++ b/src/utils/levenshtein.ts
@@ -1,0 +1,23 @@
+export function levenshtein(a: string, b: string): number {
+  const s = a.toLowerCase();
+  const t = b.toLowerCase();
+  const m = s.length;
+  const n = t.length;
+  const d: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = 0; i <= m; i++) d[i][0] = i;
+  for (let j = 0; j <= n; j++) d[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1;
+      d[i][j] = Math.min(
+        d[i - 1][j] + 1,
+        d[i][j - 1] + 1,
+        d[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  return d[m][n];
+}

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -1,0 +1,24 @@
+export function normalizeHeader(header: string) {
+  return header
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+export function splitMulti(input: string | string[] | undefined): string[] {
+  if (!input) return [];
+  const raw = Array.isArray(input) ? input.join(';') : input;
+  return raw
+    .split(/[;；、|]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function smartIncludes(haystack: string, needle: string) {
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+export function compareInsensitive(a: string, b: string) {
+  return a.localeCompare(b, undefined, { sensitivity: 'base' });
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1f2937',
+        accent: '#2563eb',
+        warning: '#f59e0b',
+        success: '#10b981'
+      }
+    }
+  },
+  plugins: []
+};

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { parseCsv } from '../src/utils/csv';
+
+describe('parseCsv', () => {
+  it('parses aliases and multi values', () => {
+    const csv = `Word,POS,English Definition,中文 释义,Collocations (EN),常用搭配(中文),Tags\n` +
+      `abate,verb,to reduce,减少,abate the pain|abate losses,减少疼痛；减少损失,law;common`;
+    const result = parseCsv(csv);
+    expect(result.all[0].coll_en).toEqual(['abate the pain', 'abate losses']);
+    expect(result.all[0].coll_zh).toEqual(['减少疼痛', '减少损失']);
+    expect(result.all[0].tags).toEqual(['law', 'common']);
+  });
+});

--- a/tests/leitner.test.ts
+++ b/tests/leitner.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import dayjs from 'dayjs';
+import { leitnerUpdate } from '../src/algos/leitner';
+
+describe('leitnerUpdate', () => {
+  it('advances box on success', () => {
+    const result = leitnerUpdate({ leibox: 1, lapses: 0 }, 4, dayjs('2023-01-01'));
+    expect(result.leibox).toBe(2);
+    expect(result.interval).toBe(1);
+  });
+
+  it('regresses on failure', () => {
+    const result = leitnerUpdate({ leibox: 3, lapses: 1 }, 1, dayjs('2023-01-01'));
+    expect(result.leibox).toBe(2);
+    expect(result.lapses).toBe(2);
+  });
+
+  it('caps at box seven', () => {
+    const result = leitnerUpdate({ leibox: 7, lapses: 0 }, 5, dayjs('2023-01-01'));
+    expect(result.leibox).toBe(7);
+    expect(dayjs(result.due).diff(dayjs('2023-01-01'), 'day')).toBe(30);
+  });
+});

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import dayjs from 'dayjs';
+import { buildQueue, getNext, pushSession } from '../src/core/queue';
+import type { Card, Prefs, SRSState } from '../src/types';
+
+const prefs: Prefs = {
+  dailyNew: 2,
+  dailyReviewCap: 5,
+  algo: 'SM2',
+  typingStrict: false,
+  clozeDensity: 'mid'
+};
+
+const cards: Card[] = [
+  {
+    id: '1',
+    word: 'abate',
+    pos: 'verb',
+    def_en: 'to reduce',
+    def_zh: '减少',
+    coll_en: [],
+    coll_zh: [],
+    usage_notes: '',
+    mnemonic: '',
+    ex_en: '',
+    ex_zh: '',
+    tags: []
+  },
+  {
+    id: '2',
+    word: 'brisk',
+    pos: 'adj',
+    def_en: 'quick',
+    def_zh: '轻快的',
+    coll_en: [],
+    coll_zh: [],
+    usage_notes: '',
+    mnemonic: '',
+    ex_en: '',
+    ex_zh: '',
+    tags: []
+  }
+];
+
+const srs: SRSState[] = [
+  {
+    cid: '1',
+    algo: 'SM2',
+    ef: 2.5,
+    interval: 1,
+    reps: 1,
+    due: dayjs().subtract(1, 'day').toISOString(),
+    lapses: 0,
+    history: []
+  }
+];
+
+describe('queue', () => {
+  it('builds due and fresh queues', () => {
+    const queue = buildQueue(cards, srs, prefs, dayjs());
+    expect(queue.due.length).toBe(1);
+    expect(queue.fresh.length).toBe(1);
+  });
+
+  it('serves session items first', () => {
+    const queue = buildQueue(cards, srs, prefs, dayjs());
+    pushSession(queue, cards[0], srs[0], -1);
+    const next = getNext(queue, Date.now());
+    expect(next?.source).toBe('session');
+  });
+});

--- a/tests/sm2.test.ts
+++ b/tests/sm2.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import dayjs from 'dayjs';
+import { sm2Update } from '../src/algos/sm2';
+
+describe('sm2Update', () => {
+  it('handles initial correct answers', () => {
+    const result = sm2Update({ ef: 2.5, reps: 0, interval: 0, lapses: 0 }, 5, dayjs('2023-01-01'));
+    expect(result.reps).toBe(1);
+    expect(result.interval).toBe(1);
+    expect(result.due).toBe(dayjs('2023-01-02').toISOString());
+  });
+
+  it('resets on failure', () => {
+    const result = sm2Update({ ef: 2.5, reps: 3, interval: 6, lapses: 0 }, 1, dayjs('2023-01-01'));
+    expect(result.reps).toBe(0);
+    expect(result.interval).toBe(1);
+    expect(result.lapses).toBe(1);
+  });
+
+  it('applies overdue penalty', () => {
+    const result = sm2Update(
+      { ef: 2.5, reps: 4, interval: 10, lapses: 0, due: dayjs('2022-12-20').toISOString() },
+      5,
+      dayjs('2023-01-05')
+    );
+    expect(result.lastGrade).toBeLessThan(5);
+  });
+
+  it('boosts ef on consecutive perfect', () => {
+    const first = sm2Update({ ef: 2.5, reps: 2, interval: 6, lapses: 0, lastGrade: 5 }, 5, dayjs('2023-01-01'));
+    expect(first.ef).toBeGreaterThan(2.5);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vitest/globals", "vite/client"]
+  },
+  "include": ["src", "tests", "vite.config.ts"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- redesign the application shell with a sidebar layout, accessible skip link, and real-time study stats to avoid blank renders and clarify navigation
- add a resilient storage layer that mirrors Dexie data into localStorage and gracefully falls back when IndexedDB is unavailable, keeping queue interactions functional
- hydrate preference state from persisted data and wire backup/import workflows to use the new storage APIs

## Testing
- npm install *(fails: npm registry returned 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e255833a48832b8a27a49e2a5809f3